### PR TITLE
Implemented exponential/logarithm functions using CORDIC algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,9 @@ Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasNativeMethods.cs
 Src/ILGPU.Algorithms/ScanReduceOperations.cs
 Src/ILGPU.Algorithms/Sequencers.cs
 Src/ILGPU.Algorithms/TypeInformation.cs
+Src/ILGPU.Algorithms/XMath/Cordic.cs
+Src/ILGPU.Algorithms/XMath/Cordic.Log.cs
+Src/ILGPU.Algorithms/XMath/Cordic.Pow.cs
 Src/ILGPU.Algorithms/XMath/Cordic.Trig.cs
 
 # Generated test source files

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
@@ -13,21 +13,21 @@ using Xunit;
     var unaryLogFunctions = new []
     {
         new XMathFunction("Log"  , "float" , new Precision(15,  6,  6)),
-        new XMathFunction("Log"  , "double", new Precision(15,  6, 15)),
+        new XMathFunction("Log"  , "double", new Precision(15, 14, 15)),
         new XMathFunction("Log10", "float" , new Precision(15,  6,  6)),
-        new XMathFunction("Log10", "double", new Precision(15,  6, 15)),
+        new XMathFunction("Log10", "double", new Precision(15, 15, 15)),
     };
 
     var unaryLog2Functions = new []
     {
         new XMathFunction("Log2" , "float" , new Precision(15,  6,  6)),
-        new XMathFunction("Log2" , "double", new Precision(15,  6, 14)),
+        new XMathFunction("Log2" , "double", new Precision(15, 14, 14)),
     };
 
     var binaryLogFunctions = new []
     {
         new XMathFunction("Log" , "float" , new Precision(15,  5,  0)),
-        new XMathFunction("Log" , "double", new Precision(15,  6,  0)),
+        new XMathFunction("Log" , "double", new Precision(15, 14,  0)),
     };
 #>
 namespace ILGPU.Algorithms.Tests

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
@@ -13,19 +13,19 @@ using Xunit;
     var powFunctions = new []
     {
         new PowFunction("Pow" , "float" , new RelativeError(0E-00, 1E-05, 1E-06)),
-        new PowFunction("Pow" , "double", new RelativeError(0E-00, 1E-05, 1E-15)),
+        new PowFunction("Pow" , "double", new RelativeError(0E-00, 1E-13, 1E-15)),
     };
 
     var exp2Functions = new []
     {
-        new PowFunction("Exp2", "float" , new RelativeError(0E-00, 0E-00, 1E-07)),
-        new PowFunction("Exp2", "double", new RelativeError(0E-00, 1E-07, 0E-00)),
+        new PowFunction("Exp2", "float" , new RelativeError(0E-00, 1E-07, 1E-07)),
+        new PowFunction("Exp2", "double", new RelativeError(0E-00, 1E-14, 0E-00)),
     };
 
     var expFunctions = new []
     {
         new PowFunction("Exp" , "float" , new RelativeError(0E-00, 1E-05, 1E-06)),
-        new PowFunction("Exp" , "double", new RelativeError(0E-00, 1E-05, 1E-15)),
+        new PowFunction("Exp" , "double", new RelativeError(0E-00, 1E-14, 1E-15)),
     };
 #>
 namespace ILGPU.Algorithms.Tests
@@ -87,13 +87,13 @@ namespace ILGPU.Algorithms.Tests
         public void <#= function.TestName #>()
         {
 <#
-            var start = 0.5;
-            var end = 40.0;
+            var start = -40.0;
+            var end = 80.0;
             var step = 0.5;
 #>
             // [<#= start #>, <#= end #>]
             var inputValues = new List<<#= function.DataType #>>();
-            for (var x = <#= start #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
+            for (var x = <#= start.ToString("F1") #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
 
             var inputArray = inputValues.ToArray();
@@ -124,13 +124,13 @@ namespace ILGPU.Algorithms.Tests
         public void <#= function.TestName #>()
         {
 <#
-            var start = 0.5;
-            var end = 40.0;
+            var start = -40.0;
+            var end = 80.0;
             var step = 0.5;
 #>
             // [<#= start #>, <#= end #>]
             var inputValues = new List<<#= function.DataType #>>();
-            for (var x = <#= start #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
+            for (var x = <#= start.ToString("F1") #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
 
             var inputArray = inputValues.ToArray();

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
@@ -12,8 +12,8 @@ using Xunit;
 <#
     var rcpFunctions = new []
     {
-        new XMathFunction("Rcp"  , "float" , new Precision(15, 15, 15)),
-        new XMathFunction("Rcp"  , "double", new Precision(15, 15, 15)),
+        new XMathFunction("Rcp"  , "float" , new Precision(15, 15,  0)),
+        new XMathFunction("Rcp"  , "double", new Precision(15, 15,  0)),
     };
 #>
 namespace ILGPU.Algorithms.Tests

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
@@ -27,11 +27,11 @@ using Xunit;
         new TrigFunction("Atan", "double", new Precision(15, 15, 15), projection: ".Select(x => Math.Tan(XMath.DegToRad((double)x)))"),
 
         new TrigFunction("Sinh", "float" , new Precision(15,  4,  4), projection: ".Select(x => XMath.DegToRad((float)x))"),
-        new TrigFunction("Sinh", "double", new Precision(15,  4, 13), projection: ".Select(x => XMath.DegToRad((double)x))"),
+        new TrigFunction("Sinh", "double", new Precision(15, 12, 13), projection: ".Select(x => XMath.DegToRad((double)x))"),
         new TrigFunction("Cosh", "float" , new Precision(15,  4,  4), projection: ".Select(x => XMath.DegToRad((float)x))"),
-        new TrigFunction("Cosh", "double", new Precision(15,  4, 13), projection: ".Select(x => XMath.DegToRad((double)x))"),
+        new TrigFunction("Cosh", "double", new Precision(15, 12, 13), projection: ".Select(x => XMath.DegToRad((double)x))"),
         new TrigFunction("Tanh", "float" , new Precision(15,  6,  6), projection: ".Select(x => XMath.DegToRad((float)x))"),
-        new TrigFunction("Tanh", "double", new Precision(15,  7, 15), projection: ".Select(x => XMath.DegToRad((double)x))"),
+        new TrigFunction("Tanh", "double", new Precision(15, 15, 15), projection: ".Select(x => XMath.DegToRad((double)x))"),
     };
 
     var binaryTrigFunctions = new []

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -91,6 +91,21 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Sequencers.cs</LastGenOutput>
     </None>
+    <None Update="XMath\Cordic.ttinclude">
+      <Generator></Generator>
+    </None>
+    <None Update="XMath\Cordic.tt">
+      <LastGenOutput>Cordic.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="XMath\Cordic.Log.tt">
+      <LastGenOutput>Cordic.Log.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="XMath\Cordic.Pow.tt">
+      <LastGenOutput>Cordic.Pow.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
     <None Update="XMath\Cordic.Trig.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Cordic.Trig.cs</LastGenOutput>
@@ -152,6 +167,21 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Sequencers.tt</DependentUpon>
+    </Compile>
+    <Compile Update="XMath\Cordic.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Cordic.tt</DependentUpon>
+    </Compile>
+    <Compile Update="XMath\Cordic.Log.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Cordic.Log.tt</DependentUpon>
+    </Compile>
+    <Compile Update="XMath\Cordic.Pow.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Cordic.Pow.tt</DependentUpon>
     </Compile>
     <Compile Update="XMath\Cordic.Trig.cs">
       <DesignTime>True</DesignTime>

--- a/Src/ILGPU.Algorithms/PTX/PTXMath.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXMath.cs
@@ -301,7 +301,7 @@ namespace ILGPU.Algorithms.PTX
         /// <summary cref="XMath.Exp(double)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Exp(double value) =>
-            Exp2(value * XMath.OneOverLn2D);
+            XMath.Cordic.Exp(value);
 
         /// <summary cref="XMath.Exp(float)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -311,7 +311,7 @@ namespace ILGPU.Algorithms.PTX
         /// <summary cref="XMath.Exp2(double)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Exp2(double value) =>
-            XMath.Exp2((float)value);
+            Exp(value * XMath.OneOverLog2ED);
 
         /// <summary cref="XMath.Exp2(float)" />
         public static float Exp2(float value) =>
@@ -334,7 +334,7 @@ namespace ILGPU.Algorithms.PTX
         /// <summary cref="XMath.Log(double)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Log(double value) =>
-            Log2(value) * XMath.OneOverLog2ED;
+            XMath.Cordic.Log(value);
 
         /// <summary cref="XMath.Log(float)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -344,7 +344,7 @@ namespace ILGPU.Algorithms.PTX
         /// <summary cref="XMath.Log10(double)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Log10(double value) =>
-            Log(value) * XMath.OneOverLn10;
+            Log(value) * XMath.OneOverLn10D;
 
         /// <summary cref="XMath.Log10(float)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -354,7 +354,7 @@ namespace ILGPU.Algorithms.PTX
         /// <summary cref="XMath.Log2(double)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Log2(double value) =>
-            XMath.Log2((float)value);
+            Log(value) * XMath.OneOverLn2D;
 
         /// <summary cref="XMath.Log2(float)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Src/ILGPU.Algorithms/XMath/Cordic.Log.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.Log.tt
@@ -1,0 +1,82 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                                www.ilgpu.net
+//
+// File: Cordic.Log.tt/Cordic.Log.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="Cordic.ttinclude"#>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+namespace ILGPU.Algorithms
+{
+    partial class XMath
+    {
+        /// <summary>
+        /// Implementation of logarithmic functions using CORDIC approximation.
+        /// </summary>
+        partial class Cordic
+        {
+            #region Logarithm
+
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Implementation of natural logarithm using CORDIC approximation.
+            /// </summary>
+            /// <param name="value">The input value</param>
+            /// <returns>The exponent of a input value raised to base e</returns>
+            public static <#= operation.DataType #> Log(<#= operation.DataType #> value)
+            {
+                // The exponential function is related to hyperbolic functions with the identity:
+                //  exp(x) = cosh(x) + sinh(x)
+                //
+                // Furthermore, the hyperbolic CORDIC algorithm cannot handle the full range of input
+                // values, so we simplify the calculations using the formula:
+                //
+                //  ln(x) = ln(base^power * multiplier)
+                //        = ln(base^power) + ln(multiplier)
+                //        = power * ln(base) + ln(multiplier)
+                //
+                // We can calculate base/power easily using repeated divisions, and using a suitable
+                // base, the multiplier fits within the CORDIC input range.
+                //
+                // NB: We picked base e, as it cancels out the ln(base).
+                //
+                // Reference:
+                //  https://en.wikipedia.org/wiki/Logarithm#Exponentiation
+                //
+                var power = 0;
+                var currValue = value;
+
+                while (currValue > E<#= operation.XMathSuffix #>)
+                {
+                    power += 1;
+                    currValue /= E<#= operation.XMathSuffix #>;
+                }
+
+                while (currValue < 1.0<#= operation.ValueSuffix #>)
+                {
+                    power -= 1;
+                    currValue *= E<#= operation.XMathSuffix #>;
+                }
+
+                // Apply <#= operation.Iterations #> iterations.
+                var cosh = currValue + 1.0<#= operation.ValueSuffix #>;
+                var sinh = currValue - 1.0<#= operation.ValueSuffix #>;
+                var radians = VectorHyperbolicIterations(cosh, sinh);
+
+                return power + (2.0<#= operation.ValueSuffix #> * radians);
+            }
+
+<# } #>
+            #endregion
+        }
+    }
+}

--- a/Src/ILGPU.Algorithms/XMath/Cordic.Pow.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.Pow.tt
@@ -1,0 +1,79 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                                www.ilgpu.net
+//
+// File: Cordic.Pow.tt/Cordic.Pow.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="Cordic.ttinclude"#>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+namespace ILGPU.Algorithms
+{
+    partial class XMath
+    {
+        /// <summary>
+        /// Implementation of exponential functions using CORDIC approximation.
+        /// </summary>
+        partial class Cordic
+        {
+            #region Exponential
+
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Implementation of e raised to a specific power using CORDIC approximation.
+            /// </summary>
+            /// <param name="value">Specifies the power</param>
+            /// <returns>The number e raised to the specified power</returns>
+            public static <#= operation.DataType #> Exp(<#= operation.DataType #> value)
+            {
+                // Deal with negative exponents
+                if (value < 0)
+                    return 1.0<#= operation.ValueSuffix #> / Exp(-1.0<#= operation.ValueSuffix #> * value);
+
+                // The exponential function is related to hyperbolic functions with the identity:
+                //  exp(x) = cosh(x) + sinh(x)
+                //
+                // Furthermore, the hyperbolic CORDIC algorithm cannot handle the full range of input
+                // values, so we simplify the calculations using the formula:
+                //
+                //  exp(x) = exp(quotient * ln(2) + remainder)
+                //         = exp(quotient * ln(2)) * exp(remainder)
+                //         = exp(ln(2)) ^ quotient * exp(remainder)
+                //         = 2^quotient * exp(remainder)
+                //
+                // We can calculate 2^quotient easily using repeated multiplication, and the remainder fits
+                // within the CORDIC input range.
+                //
+                // Reference:
+                //  https://en.wikipedia.org/wiki/Hyperbolic_functions#Relationship_to_the_exponential_function
+                //  https://en.wikipedia.org/wiki/Exponentiation#Identities_and_properties
+                //
+                var quotient = (int)Floor(value / Ln2<#= operation.XMathSuffix #>);
+                var remainder = value - quotient * Ln2<#= operation.XMathSuffix #>;
+
+                // Apply <#= operation.Iterations #> iterations.
+                RotateHyperbolicIterations(remainder, out var cosh, out var sinh);
+
+                var twoPowQuotient = 1.0<#= operation.ValueSuffix #>;
+                while (quotient > 0)
+                {
+                    twoPowQuotient *= 2.0<#= operation.ValueSuffix #>;
+                    quotient -= 1;
+                }
+
+                return twoPowQuotient * (cosh + sinh) * HyperbolicGain<#= operation.XMathSuffix #>;
+            }
+
+<# } #>
+            #endregion
+        }
+    }
+}

--- a/Src/ILGPU.Algorithms/XMath/Cordic.Trig.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.Trig.tt
@@ -10,160 +10,22 @@
 // -----------------------------------------------------------------------------
 
 <#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="Cordic.ttinclude"#>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
-<#
-    var operations = new []
-    {
-        new { DataType = "float", ValueSuffix = "f", Iterations = 24, Format = "E9", XMathSuffix = "" },
-        new { DataType = "double", ValueSuffix = "", Iterations = 53, Format = "E17", XMathSuffix = "D" },
-    };
-
-    // Pre-calculate a table of inverse tangents of negative powers of two, in radians.
-    // i.e. angles = atan(2.^(-i))
-    //
-    // This table is used by the CORDIC algorithm to compute sine/cosine in rotation mode, and inverse tangent in vectoring mode.
-    var maxIterations  = operations.Max(x => x.Iterations);
-    var angles = new double[maxIterations];
-
-    for (var i = 0; i < maxIterations; i++)
-    {
-        angles[i] = Math.Atan(Math.Pow(2, -i));
-    }
-
-    // A table of products of reciprocal lengths
-    // i.e. kvalues = cumprod(1./ sqrt(1 + 2.^(-2i)))
-    //
-    // CORDIC rotations accumulate errors with each rotation.
-    // Pre-calculate a table of 'corrections' that will be used by the CORDIC algorithm to scale the final result.
-    var kvalues = new double[maxIterations];
-
-    kvalues[0] = 1 / Math.Sqrt(1 + Math.Pow(2, 0));
-    for (var i = 1; i < kvalues.Length; i++)
-    {
-        kvalues[i] = kvalues[i - 1] * (1 / Math.Sqrt(1 + Math.Pow(2, i * -2)));
-    }
-
-#>
-using ILGPU.Util;
-using System.Runtime.CompilerServices;
-
 namespace ILGPU.Algorithms
 {
     partial class XMath
     {
         /// <summary>
         /// Implementation of trigonometric transcendental functions using CORDIC approximation.
-        /// https://en.wikipedia.org/wiki/CORDIC
-        ///
-        /// NB: CORDIC is typically implemented using a lookup table with angles. However, since
-        /// these are not currently available, we unroll the loop.
         /// </summary>
-        internal static partial class Cordic
+        partial class Cordic
         {
-            #region Utilities
-
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Performs the common matrix multiplication used by CORDIC (a 2x2 matrix with a 2x1 matrix).
-            /// </summary>
-            /// <param name="cos">The current cosine value. Filled in with the result cosine value</param>
-            /// <param name="sin">The current sine value. Filled in with the result sine value</param>
-            /// <param name="factor">The multiplication factor</param>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static void MatrixMultiply(ref <#= operation.DataType #> cos, ref <#= operation.DataType #> sin, <#= operation.DataType #> factor)
-            {
-                // Matrix multiplication
-                // [ 1     , -factor ] [ currCos ]
-                // [ factor, 1       ] [ currSin ]
-                var currCos = cos;
-                var currSin = sin;
-                var nextCos = currCos - (currSin * factor);
-                var nextSin = (currCos * factor) + currSin;
-
-                cos = nextCos;
-                sin = nextSin;
-            }
-
-<# } #>
-            #endregion
-
             #region Trigonometric
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Corrects the inaccuracies gained by rotating through the <#= operation.Iterations #> iterations.
-            /// NB: We are using a pre-defined number of iterations, so the scaling can be a constant value.
-            /// </summary>
-            private const <#= operation.DataType #> Gain<#= operation.XMathSuffix #> = <#= kvalues[operation.Iterations - 1].ToString(operation.Format) #><#= operation.ValueSuffix #>;
 
-<# } #>
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Applies the next iteration of CORDIC rotation
-            /// </summary>
-            /// <param name="angle">The angle for this iteration</param>
-            /// <param name="cos">The current cosine value</param>
-            /// <param name="sin">The current sine value</param>
-            /// <param name="radians">The current radians value</param>
-            /// <param name="powerOfTwo">The current multiplier</param>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static void NextRotateIteration(<#= operation.DataType #> angle, ref <#= operation.DataType #> cos, ref <#= operation.DataType #> sin, ref <#= operation.DataType #> radians, ref <#= operation.DataType #> powerOfTwo)
-            {
-                var sigma = Utilities.Select(radians < 0, -1, 1);
-                var factor = sigma * powerOfTwo;
-
-                MatrixMultiply(ref cos, ref sin, factor);
-
-                // Update the remaining angle
-                radians -= sigma * angle;
-                powerOfTwo /= 2.0<#= operation.ValueSuffix #>;
-            }
-
-<# } #>
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Applies the iterations of CORDIC rotations
-            /// </summary>
-            /// <param name="radians">The radians value</param>
-            /// <param name="cos">Filled in with result cosine value</param>
-            /// <param name="sin">Filled in with result sine value</param>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static void RotateIterations(<#= operation.DataType #> radians, out <#= operation.DataType #> cos, out <#= operation.DataType #> sin)
-            {
-                // Apply <#= operation.Iterations #> iterations.
-                var currCos = 1.0<#= operation.ValueSuffix #>;
-                var currSin = 0.0<#= operation.ValueSuffix #>;
-                var currRadians = radians;
-                var powerOfTwo = 1.0<#= operation.ValueSuffix #>;
-
-<# for (var i = 0; i < operation.Iterations; i++) { #>
-                NextRotateIteration(<#= angles[i].ToString(operation.Format) #><#= operation.ValueSuffix #>, ref currCos, ref currSin, ref currRadians, ref powerOfTwo);
-<# } #>
-
-                cos = currCos;
-                sin = currSin;
-            }
-
-<# } #>
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Ensures that the radians are within the range [-PI, PI]
-            /// </summary>
-            /// <param name="radians">The angle in radians</param>
-            /// <returns>The angle, in radians</returns>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static <#= operation.DataType #> RangeLimit(<#= operation.DataType #> radians)
-            {
-                while (radians < -PI<#= operation.XMathSuffix #>)
-                    radians += 2 * PI<#= operation.XMathSuffix #>;
-                while (radians > PI<#= operation.XMathSuffix #>)
-                    radians -= 2 * PI<#= operation.XMathSuffix #>;
-                return radians;
-            }
-
-<# } #>
 <#  foreach (var operation in operations) { #>
             /// <summary>
             /// Implementation of sine approximation using CORDIC.
@@ -262,51 +124,6 @@ namespace ILGPU.Algorithms
 
 <#  foreach (var operation in operations) { #>
             /// <summary>
-            /// Applies the next iteration of CORDIC vectoring
-            /// </summary>
-            /// <param name="angle">The angle for this iteration</param>
-            /// <param name="cos">The current cosine value</param>
-            /// <param name="sin">The current sine value</param>
-            /// <param name="radians">The current radians value</param>
-            /// <param name="powerOfTwo">The current multiplier</param>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static void NextVectorIteration(<#= operation.DataType #> angle, ref <#= operation.DataType #> cos, ref <#= operation.DataType #> sin, ref <#= operation.DataType #> radians, ref <#= operation.DataType #> powerOfTwo)
-            {
-                var sigma = Utilities.Select(sin >= 0, -1, 1);
-                var factor = sigma * powerOfTwo;
-
-                MatrixMultiply(ref cos, ref sin, factor);
-
-                radians -= sigma * angle;
-                powerOfTwo /= 2.0<#= operation.ValueSuffix #>;
-            }
-
-<# } #>
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Applies the iterations of CORDIC vectoring
-            /// </summary>
-            /// <param name="target">The target sine value</param>
-            /// <returns>The angle in radians</returns>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static <#= operation.DataType #> VectorIterations(<#= operation.DataType #> target)
-            {
-                // Apply <#= operation.Iterations #> iterations.
-                var currCos = 1.0<#= operation.ValueSuffix #>;
-                var currSin = target;
-                var currRadians = 0.0<#= operation.ValueSuffix #>;
-                var powerOfTwo = 1.0<#= operation.ValueSuffix #>;
-
-<# for (var i = 0; i < operation.Iterations; i++) { #>
-                NextVectorIteration(<#= angles[i].ToString(operation.Format) #><#= operation.ValueSuffix #>, ref currCos, ref currSin, ref currRadians, ref powerOfTwo);
-<# } #>
-
-                return currRadians;
-            }
-
-<# } #>
-<#  foreach (var operation in operations) { #>
-            /// <summary>
             /// Implementation of inverse tangent approximation using CORDIC.
             /// </summary>
             /// <param name="value">The tangent of an angle</param>
@@ -342,62 +159,6 @@ namespace ILGPU.Algorithms
                 else
                     return 0;
             }
-
-<# } #>
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Implementation of inverse sine approximation using CORDIC.
-            /// </summary>
-            /// <param name="value">The sine of an angle</param>
-            /// <returns>The angle in radians</returns>
-            public static <#= operation.DataType #> Asin(<#= operation.DataType #> value)
-            {
-                var currCos = 1.0<#= operation.ValueSuffix #>;
-                var currSin = 0.0<#= operation.ValueSuffix #>;
-                var radians = 0.0<#= operation.ValueSuffix #>;
-                var target = value;
-                var powerOfTwo = 1.0<#= operation.ValueSuffix #>;
-
-                // Apply <#= operation.Iterations #> iterations.
-<# for (var i = 0; i < operation.Iterations; i++) { #>
-                NextRotateIterationAsin(<#= angles[i].ToString(operation.Format) #><#= operation.ValueSuffix #>, ref currCos, ref currSin, ref radians, ref target, ref powerOfTwo);
-<# } #>
-
-                return radians;
-            }
-
-            /// <summary>
-            /// Applies the next iteration of CORDIC rotation for inverse sine
-            /// </summary>
-            /// <param name="angle">The angle for this iteration</param>
-            /// <param name="currCos">The current cosine value</param>
-            /// <param name="currSin">The current sine value</param>
-            /// <param name="radians">The current radians value</param>
-            /// <param name="target">The target value</param>
-            /// <param name="powerOfTwo">The current multiplier</param>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static void NextRotateIterationAsin(<#= operation.DataType #> angle, ref <#= operation.DataType #> currCos, ref <#= operation.DataType #> currSin, ref <#= operation.DataType #> radians, ref <#= operation.DataType #> target, ref <#= operation.DataType #> powerOfTwo)
-            {
-                var sigma = Utilities.Select(currCos < 0 && currSin <= target || currCos >= 0 && currSin > target, -1, 1);
-                var factor = sigma * powerOfTwo;
-
-                MatrixMultiply(ref currCos, ref currSin, factor);
-                MatrixMultiply(ref currCos, ref currSin, factor);
-                radians += 2 * sigma * angle;
-                target += target * powerOfTwo * powerOfTwo;
-
-                powerOfTwo /= 2.0<#= operation.ValueSuffix #>;
-            }
-
-<# } #>
-<#  foreach (var operation in operations) { #>
-            /// <summary>
-            /// Implementation of inverse cosine approximation using CORDIC.
-            /// </summary>
-            /// <param name="value">The cosine of an angle</param>
-            /// <returns>The angle in radians</returns>
-            public static <#= operation.DataType #> Acos(<#= operation.DataType #> value) =>
-                PIHalf<#= operation.XMathSuffix #> - Asin(value);
 
 <# } #>
             #endregion

--- a/Src/ILGPU.Algorithms/XMath/Cordic.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.tt
@@ -1,0 +1,400 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                                www.ilgpu.net
+//
+// File: Cordic.tt/Cordic.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="Cordic.ttinclude"#>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+    // Pre-calculate a table of inverse tangents of negative powers of two, in radians.
+    // i.e. angles = atan(2.^(-i))
+    //
+    // This table is used by the CORDIC algorithm to compute sine/cosine in rotation mode, and inverse tangent in vectoring mode.
+    //
+    var angles = new double[maxIterations];
+    var kvalues = new double[maxIterations];
+
+    for (var i = 0; i < maxIterations; i++)
+        angles[i] = Math.Atan(Math.Pow(2, -i));
+
+    // A table of products of reciprocal lengths
+    // i.e. kvalues = cumprod(cos(atan(2.^(-i))
+    //
+    // CORDIC rotations accumulate errors with each rotation.
+    // Pre-calculate a table of 'corrections' that will be used by the CORDIC algorithm to scale the final result.
+    //
+    kvalues[0] = Math.Cos(angles[0]);
+    for (var i = 1; i < kvalues.Length; i++)
+        kvalues[i] = kvalues[i - 1] * Math.Cos(angles[i]);
+
+    // For hyperbolic mode, pre-calculate a table of inverse hyperbolic tangents of negative powers of two.
+    // i.e. hyperbolicAngles = atanh(2.^(-i))
+    //                       = 0.5 * ln ((1 + 2.^(-i)) / 1 - 2.^(-i))
+    //
+    var hyperbolicAngles = new double[maxIterations];
+
+    for (var i = 0; i < maxIterations; i++)
+    {
+        var h = Math.Pow(2, -(i + 1));
+        hyperbolicAngles[i] = 0.5 * Math.Log((1.0 + h) / (1.0 - h));
+    }
+
+    // Hyperbolic mode applies a second multiplication every 3k + 1 iterations.
+    // i.e. 4, 13, 40, 121... k, 3k + 1
+    var hyperbolicNumMultiplications = new int[maxIterations];
+    var k = 4;
+
+    hyperbolicNumMultiplications[0] = 1;
+    for (var i = 1; i < maxIterations; i++)
+    {
+        if (i == k - 1)
+        {
+            hyperbolicNumMultiplications[i] = 2;
+            k = 3 * k + 1;
+        }
+        else
+            hyperbolicNumMultiplications[i] = 1;
+    }
+#>
+using ILGPU.Util;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Algorithms
+{
+    partial class XMath
+    {
+        /// <summary>
+        /// Implementation of trigonometric/hyperbolic rotation and vector mode functions using CORDIC approximation.
+        /// https://en.wikipedia.org/wiki/CORDIC
+        ///
+        /// NB: CORDIC is typically implemented using a lookup table with angles. However, since
+        /// these are not currently available, we unroll the loop.
+        /// </summary>
+        internal static partial class Cordic
+        {
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Corrects the inaccuracies gained by rotating through the <#= operation.Iterations #> iterations.
+            /// NB: We are using a pre-defined number of iterations, so the scaling can be a constant value.
+            /// </summary>
+            private const <#= operation.DataType #> Gain<#= operation.XMathSuffix #> = <#= kvalues[operation.Iterations - 1].ToString(operation.Format) #><#= operation.ValueSuffix #>;
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Corrects the inaccuracies gained by rotating through the <#= operation.Iterations #> iterations.
+            /// NB: We are using a pre-defined number of iterations, so the scaling can be a constant value.
+            /// </summary>
+            private static readonly <#= operation.DataType #> HyperbolicGain<#= operation.XMathSuffix #> = HyperbolicGainFromCoshZero<#= operation.XMathSuffix #>();
+
+<# } #>
+            #region Utilities
+
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Calculates the inaccuracy gained by calculating the baseline of Cosh(0).
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static <#= operation.DataType #> HyperbolicGainFromCoshZero<#= operation.XMathSuffix #>()
+            {
+                // Cosh(0) should return 1. Any differences reflects inaccuracies in the CORDIC algorithm.
+                //
+                // Ideally, we should be able to calculate cumprod(Cosh(Atanh(2.^(-i)))), similar to the
+                // standard/circular CORDIC algorithm. However, the idealized constant converges at 1.2051,
+                // where-as our hyperbolic CORDIC algorithm produces a gain of 1.2075. As a workaround,
+                // calculate the gain at runtime using the real CORDIC algorithm.
+
+                // Apply <#= operation.Iterations #> iterations.
+                RotateHyperbolicIterations(0.0<#= operation.ValueSuffix #>, out var cosh, out _);
+                return 1.0<#= operation.ValueSuffix #> / cosh;
+            }
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Performs the common matrix multiplication used by CORDIC (a 2x2 matrix with a 2x1 matrix).
+            /// </summary>
+            /// <param name="cos">The current cosine value. Filled in with the result cosine value</param>
+            /// <param name="sin">The current sine value. Filled in with the result sine value</param>
+            /// <param name="factor">The multiplication factor</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void MatrixMultiply(ref <#= operation.DataType #> cos, ref <#= operation.DataType #> sin, <#= operation.DataType #> factor)
+            {
+                // Matrix multiplication
+                // [ 1     , -factor ] [ currCos ]
+                // [ factor, 1       ] [ currSin ]
+                var currCos = cos;
+                var currSin = sin;
+                var nextCos = currCos - (currSin * factor);
+                var nextSin = (currCos * factor) + currSin;
+
+                cos = nextCos;
+                sin = nextSin;
+            }
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Multiplies a 2x2 matrix with a 2x1 matrix for hyperbolic iterations.
+            /// </summary>
+            /// <param name="cosh">The current hyperbolic cosine value. Filled in with the result hyperbolic cosine value</param>
+            /// <param name="sinh">The current hyperbolic sine value. Filled in with the result hyperbolic sine value</param>
+            /// <param name="factor">The multiplication factor</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void MatrixMultiplyHyperbolic(ref <#= operation.DataType #> cosh, ref <#= operation.DataType #> sinh, <#= operation.DataType #> factor)
+            {
+                // Matrix multiplication
+                // [ 1     , factor ] [ currCos ]
+                // [ factor, 1      ] [ currSin ]
+                var currCosh = cosh;
+                var currSinh = sinh;
+                var nextCosh = currCosh + (currSinh * factor);
+                var nextSinh = (currCosh * factor) + currSinh;
+
+                cosh = nextCosh;
+                sinh = nextSinh;
+            }
+
+<# } #>
+            #endregion
+
+            #region Trigonometric
+
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Ensures that the radians are within the range [-PI, PI]
+            /// </summary>
+            /// <param name="radians">The angle in radians</param>
+            /// <returns>The angle, in radians</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static <#= operation.DataType #> RangeLimit(<#= operation.DataType #> radians)
+            {
+                while (radians < -PI<#= operation.XMathSuffix #>)
+                    radians += 2 * PI<#= operation.XMathSuffix #>;
+                while (radians > PI<#= operation.XMathSuffix #>)
+                    radians -= 2 * PI<#= operation.XMathSuffix #>;
+                return radians;
+            }
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the next iteration of CORDIC rotation
+            /// </summary>
+            /// <param name="angle">The angle for this iteration</param>
+            /// <param name="cos">The current cosine value</param>
+            /// <param name="sin">The current sine value</param>
+            /// <param name="radians">The current radians value</param>
+            /// <param name="powerOfTwo">The current multiplier</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void NextRotateIteration(<#= operation.DataType #> angle, ref <#= operation.DataType #> cos, ref <#= operation.DataType #> sin, ref <#= operation.DataType #> radians, ref <#= operation.DataType #> powerOfTwo)
+            {
+                var sigma = Utilities.Select(radians < 0, -1, 1);
+                var factor = sigma * powerOfTwo;
+
+                MatrixMultiply(ref cos, ref sin, factor);
+
+                // Update the remaining angle
+                radians -= sigma * angle;
+                powerOfTwo /= 2.0<#= operation.ValueSuffix #>;
+            }
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the iterations of CORDIC rotations
+            /// </summary>
+            /// <param name="radians">The radians value</param>
+            /// <param name="cos">Filled in with result cosine value</param>
+            /// <param name="sin">Filled in with result sine value</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void RotateIterations(<#= operation.DataType #> radians, out <#= operation.DataType #> cos, out <#= operation.DataType #> sin)
+            {
+                // Apply <#= operation.Iterations #> iterations.
+                var currCos = 1.0<#= operation.ValueSuffix #>;
+                var currSin = 0.0<#= operation.ValueSuffix #>;
+                var currRadians = radians;
+                var powerOfTwo = 1.0<#= operation.ValueSuffix #>;
+
+<# for (var i = 0; i < operation.Iterations; i++) { #>
+                NextRotateIteration(<#= angles[i].ToString(operation.Format) #><#= operation.ValueSuffix #>, ref currCos, ref currSin, ref currRadians, ref powerOfTwo);
+<# } #>
+
+                cos = currCos;
+                sin = currSin;
+            }
+
+<# } #>
+            #endregion
+
+            #region Inverse Trigonometric
+
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the next iteration of CORDIC vectoring
+            /// </summary>
+            /// <param name="angle">The angle for this iteration</param>
+            /// <param name="cos">The current cosine value</param>
+            /// <param name="sin">The current sine value</param>
+            /// <param name="radians">The current radians value</param>
+            /// <param name="powerOfTwo">The current multiplier</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void NextVectorIteration(<#= operation.DataType #> angle, ref <#= operation.DataType #> cos, ref <#= operation.DataType #> sin, ref <#= operation.DataType #> radians, ref <#= operation.DataType #> powerOfTwo)
+            {
+                var sigma = Utilities.Select(sin >= 0, -1, 1);
+                var factor = sigma * powerOfTwo;
+
+                MatrixMultiply(ref cos, ref sin, factor);
+
+                radians -= sigma * angle;
+                powerOfTwo /= 2.0<#= operation.ValueSuffix #>;
+            }
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the iterations of CORDIC vectoring
+            /// </summary>
+            /// <param name="target">The target sine value</param>
+            /// <returns>The angle in radians</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static <#= operation.DataType #> VectorIterations(<#= operation.DataType #> target)
+            {
+                // Apply <#= operation.Iterations #> iterations.
+                var currCos = 1.0<#= operation.ValueSuffix #>;
+                var currSin = target;
+                var currRadians = 0.0<#= operation.ValueSuffix #>;
+                var powerOfTwo = 1.0<#= operation.ValueSuffix #>;
+
+<# for (var i = 0; i < operation.Iterations; i++) { #>
+                NextVectorIteration(<#= angles[i].ToString(operation.Format) #><#= operation.ValueSuffix #>, ref currCos, ref currSin, ref currRadians, ref powerOfTwo);
+<# } #>
+
+                return currRadians;
+            }
+
+<# } #>
+            #endregion
+
+            #region Hyperbolic
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the next iteration of CORDIC hyperbolic rotation
+            /// </summary>
+            /// <param name="angle">The angle for this iteration</param>
+            /// <param name="cosh">The current cosh value</param>
+            /// <param name="sinh">The current sinh value</param>
+            /// <param name="radians">The current radians value</param>
+            /// <param name="powerOfTwo">The current multiplier</param>
+            /// <param name="numMultiplications">The number of multiplications in this loop</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void NextRotateHyperbolicIteration(<#= operation.DataType #> angle, ref <#= operation.DataType #> cosh, ref <#= operation.DataType #> sinh, ref <#= operation.DataType #> radians, ref <#= operation.DataType #> powerOfTwo, int numMultiplications)
+            {
+                // Apply second multiplication every 3k + 1 multiplcations
+                for (var i = 0; i < numMultiplications; i++)
+                {
+                    var sigma = Utilities.Select(radians < 0, -1, 1);
+                    var factor = sigma * powerOfTwo;
+
+                    MatrixMultiplyHyperbolic(ref cosh, ref sinh, factor);
+                    radians -= sigma * angle;
+                }
+
+                powerOfTwo /= 2.0<#= operation.ValueSuffix #>;
+            }
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the iterations of CORDIC hyperbolic rotations
+            /// </summary>
+            /// <param name="radians">The current radians value</param>
+            /// <param name="cosh">The current cosh value</param>
+            /// <param name="sinh">The current sinh value</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void RotateHyperbolicIterations(<#= operation.DataType #> radians, out <#= operation.DataType #> cosh, out <#= operation.DataType #> sinh)
+            {
+                // Apply <#= operation.Iterations #> iterations.
+                var currCosh = 1.0<#= operation.ValueSuffix #>;
+                var currSinh = 0.0<#= operation.ValueSuffix #>;
+                var currRadians = radians;
+                var powerOfTwo = 0.5<#= operation.ValueSuffix #>;
+
+<# for (var i = 0; i < operation.Iterations; i++) { #>
+                NextRotateHyperbolicIteration(<#= hyperbolicAngles[i].ToString(operation.Format) #><#= operation.ValueSuffix #>, ref currCosh, ref currSinh, ref currRadians, ref powerOfTwo, <#= hyperbolicNumMultiplications[i] #>);
+<# } #>
+
+                cosh = currCosh;
+                sinh = currSinh;
+            }
+
+<# } #>
+            #endregion
+
+            #region Inverse Hyperbolic
+
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the next iteration of CORDIC hyperbolic vectoring
+            /// </summary>
+            /// <param name="angle">The angle for this iteration</param>
+            /// <param name="cosh">The current cosh value</param>
+            /// <param name="sinh">The current sinh value</param>
+            /// <param name="radians">The current radians value</param>
+            /// <param name="powerOfTwo">The current multiplier</param>
+            /// <param name="numMultiplications">The number of multiplications in this loop</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void NextVectorHyperbolicIteration(<#= operation.DataType #> angle, ref <#= operation.DataType #> cosh, ref <#= operation.DataType #> sinh, ref <#= operation.DataType #> radians, ref <#= operation.DataType #> powerOfTwo, int numMultiplications)
+            {
+                // Apply second multiplication every 3k + 1 multiplcations
+                for (var i = 0; i < numMultiplications; i++)
+                {
+                    var sigma = Utilities.Select(sinh < 0, 1, -1);
+                    var factor = sigma * powerOfTwo;
+
+                    MatrixMultiplyHyperbolic(ref cosh, ref sinh, factor);
+                    radians -= sigma * angle;
+                }
+
+                powerOfTwo /= 2.0<#= operation.ValueSuffix #>;
+            }
+
+<# } #>
+<#  foreach (var operation in operations) { #>
+            /// <summary>
+            /// Applies the iterations of CORDIC hyperbolic vectoring
+            /// </summary>
+            /// <param name="cosh">The current cosh value</param>
+            /// <param name="sinh">The current sinh value</param>
+            /// <returns>The angle in radians</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static <#= operation.DataType #> VectorHyperbolicIterations(<#= operation.DataType #> cosh, <#= operation.DataType #> sinh)
+            {
+                // Apply <#= operation.Iterations #> iterations.
+                var currCosh = cosh;
+                var currSinh = sinh;
+                var currRadians = 0.0<#= operation.ValueSuffix #>;
+                var powerOfTwo = 0.5<#= operation.ValueSuffix #>;
+
+<# for (var i = 0; i < operation.Iterations; i++) { #>
+                NextVectorHyperbolicIteration(<#= hyperbolicAngles[i].ToString(operation.Format) #><#= operation.ValueSuffix #>, ref currCosh, ref currSinh, ref currRadians, ref powerOfTwo, <#= hyperbolicNumMultiplications[i] #>);
+<# } #>
+
+                return currRadians;
+            }
+
+<# } #>
+            #endregion
+        }
+    }
+}

--- a/Src/ILGPU.Algorithms/XMath/Cordic.ttinclude
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.ttinclude
@@ -1,0 +1,12 @@
+﻿<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#
+    var operations = new []
+    {
+        new { DataType = "float", ValueSuffix = "f", Iterations = 24, Format = "E9", XMathSuffix = "" },
+        new { DataType = "double", ValueSuffix = "", Iterations = 53, Format = "E17", XMathSuffix = "D" },
+    };
+
+    var maxIterations  = operations.Max(x => x.Iterations);
+#>


### PR DESCRIPTION
Added CORDIC implementations for `Exp` and `Log`. These had nice benefits to many other `PTXMath` functions, raising the standard across the board.

Also restructured the common functions into `Codic.tt` so that `Cordic.Pow.tt` and `Cordic.Log.tt` could share code.

Note that the range input values for the Exp unit tests have been increased to cover negative exponents as well as a larger positive range. This has highlighted a minor variance in the Cuda Exp2 intrinsic. Previously, it was not possible to use such a large range because of limitations in the Cuda implementation.