### PR TITLE
Added implementation of Rcp and Log(x, y) for OpenCL

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
@@ -26,8 +26,8 @@ using Xunit;
 
     var binaryLogFunctions = new []
     {
-        new XMathFunction("Log" , "float" , new Precision(15,  5,  0)),
-        new XMathFunction("Log" , "double", new Precision(15, 14,  0)),
+        new XMathFunction("Log" , "float" , new Precision(15,  5,  6)),
+        new XMathFunction("Log" , "double", new Precision(15, 14, 14)),
     };
 #>
 namespace ILGPU.Algorithms.Tests
@@ -140,17 +140,6 @@ namespace ILGPU.Algorithms.Tests
             using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
 
             input.CopyFrom(inputArray, 0, 0, inputArray.Length);
-<# if (function.Name == "Log") { #>
-            if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-            {
-                // TODO: Implement OpenCL support for XMath.Log(<#= function.DataType #>, <#= function.DataType #>)
-                var ae = Assert.Throws<AggregateException>(() => Execute(input.Length, input.View, output.View));
-                Assert.Single(ae.InnerExceptions);
-                Assert.IsType<Backends.NotSupportedIntrinsicException>(ae.InnerExceptions[0]);
-                return;
-            }
-<# } #>
-
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(v => Math<#= function.MathSuffix #>.Log(v.X, v.Y)).ToArray();

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
@@ -12,8 +12,8 @@ using Xunit;
 <#
     var rcpFunctions = new []
     {
-        new XMathFunction("Rcp"  , "float" , new Precision(15, 15,  0)),
-        new XMathFunction("Rcp"  , "double", new Precision(15, 15,  0)),
+        new XMathFunction("Rcp"  , "float" , new Precision(15, 15,  7)),
+        new XMathFunction("Rcp"  , "double", new Precision(15, 15, 15)),
     };
 #>
 namespace ILGPU.Algorithms.Tests

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
@@ -47,18 +47,6 @@ namespace ILGPU.Algorithms.Tests
             using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
 
             input.CopyFrom(inputArray, 0, 0, inputArray.Length);
-
-<# if (function.Name == "Rcp") { #>
-            if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-            {
-                // TODO: Implement OpenCL support for XMath.Rcp
-                var ae = Assert.Throws<AggregateException>(() => Execute(input.Length, input.View, output.View));
-                Assert.Single(ae.InnerExceptions);
-                Assert.IsType<Backends.NotSupportedIntrinsicException>(ae.InnerExceptions[0]);
-                return;
-            }
-<# } #>
-
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(x => 1 / x).ToArray();

--- a/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
@@ -17,14 +17,7 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 <#
-var softwareMathFunctions = new ValueTuple<string, Type, string, string>[]
-    {
-        UnaryMathFunctions[18], // Rcp
-        UnaryMathFunctions[19], // Rcp
-    };
-var unaryMathFunctions = UnaryMathFunctions.Where(t =>
-    !softwareMathFunctions.Any(
-        t2 => t.Item1 == t2.Item1 && t.Item2 == t2.Item2));
+var unaryMathFunctions = UnaryMathFunctions;
 var binaryMathFunctions = BinaryMathFunctions;
 #>
 using ILGPU.IR.Intrinsics;
@@ -37,13 +30,6 @@ namespace ILGPU.Algorithms.CL
         public static void EnableCLAlgorithms(IntrinsicImplementationManager manager)
         {
             // Register math intrinsics
-<# foreach (var (name, type, kind, basicType) in softwareMathFunctions) { #>
-            manager.RegisterUnaryArithmetic(
-                UnaryArithmeticKind.<#= kind #>,
-                BasicValueType.<#= basicType #>,
-                GetMathIntrinsic("<#= name #>", typeof(<#= type #>)));
-<# } #>
-
 <# foreach (var (name, type, kind, basicType) in binaryMathFunctions) { #>
             manager.RegisterBinaryArithmetic(
                 BinaryArithmeticKind.<#= kind #>,

--- a/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
@@ -17,7 +17,11 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 <#
-var unaryMathFunctions = UnaryMathFunctions;
+var unaryMathFunctions = new ValueTuple<string, Type, string, string>[]
+    {
+        UnaryMathFunctions[18], // Rcp
+        UnaryMathFunctions[19], // Rcp
+    };
 var binaryMathFunctions = BinaryMathFunctions;
 #>
 using ILGPU.IR.Intrinsics;

--- a/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
@@ -16,7 +16,19 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
+<#
+var softwareMathFunctions = new ValueTuple<string, Type, string, string>[]
+    {
+        UnaryMathFunctions[18], // Rcp
+        UnaryMathFunctions[19], // Rcp
+    };
+var unaryMathFunctions = UnaryMathFunctions.Where(t =>
+    !softwareMathFunctions.Any(
+        t2 => t.Item1 == t2.Item1 && t.Item2 == t2.Item2));
+var binaryMathFunctions = BinaryMathFunctions;
+#>
 using ILGPU.IR.Intrinsics;
+using ILGPU.IR.Values;
 
 namespace ILGPU.Algorithms.CL
 {
@@ -24,6 +36,28 @@ namespace ILGPU.Algorithms.CL
     {
         public static void EnableCLAlgorithms(IntrinsicImplementationManager manager)
         {
+            // Register math intrinsics
+<# foreach (var (name, type, kind, basicType) in softwareMathFunctions) { #>
+            manager.RegisterUnaryArithmetic(
+                UnaryArithmeticKind.<#= kind #>,
+                BasicValueType.<#= basicType #>,
+                GetMathIntrinsic("<#= name #>", typeof(<#= type #>)));
+<# } #>
+
+<# foreach (var (name, type, kind, basicType) in binaryMathFunctions) { #>
+            manager.RegisterBinaryArithmetic(
+                BinaryArithmeticKind.<#= kind #>,
+                BasicValueType.<#= basicType #>,
+                GetMathIntrinsic("<#= name #>", typeof(<#= type #>), typeof(<#= type #>)));
+<# } #>
+
+<# foreach (var (name, type, kind, basicType) in unaryMathFunctions) { #>
+            manager.RegisterUnaryArithmetic(
+                UnaryArithmeticKind.<#= kind #>,
+                BasicValueType.<#= basicType #>,
+                MathCodeGeneratorIntrinsic);
+<# } #>
+
             // Register group intrinsics
 <# foreach (var name in GroupFunctions.Take(4)) { #>
             RegisterIntrinsicCodeGenerator(

--- a/Src/ILGPU.Algorithms/CL/CLMath.cs
+++ b/Src/ILGPU.Algorithms/CL/CLMath.cs
@@ -1,0 +1,329 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                                www.ilgpu.net
+//
+// File: CLMath.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+using ILGPU.Backends.OpenCL;
+using ILGPU.IR;
+using ILGPU.IR.Values;
+using ILGPU.Util;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Algorithms.CL
+{
+    static class CLMath
+    {
+        #region Code Generator
+
+        /// <summary>
+        /// Generates intrinsic math instructions for the following kinds:
+        /// Rcp, Sqrt, Sin, Cos, Exp2, Log2, IsInf, IsNaN
+        /// </summary>
+        /// <param name="backend">The current backend.</param>
+        /// <param name="codeGenerator">The code generator.</param>
+        /// <param name="value">The value to generate code for.</param>
+        public static void GenerateMathIntrinsic(
+            CLBackend backend,
+            CLCodeGenerator codeGenerator,
+            Value value)
+        {
+            var arithmeticValue = value as UnaryArithmeticValue;
+            var instruction = CLInstructions.GetArithmeticOperation(
+                arithmeticValue.Kind,
+                arithmeticValue.BasicValueType.IsFloat(),
+                out _);
+
+            var argument = codeGenerator.Load(arithmeticValue.Value);
+            var targetRegister = codeGenerator.Allocate(arithmeticValue);
+            using (var command = codeGenerator.BeginStatement(targetRegister, instruction))
+            {
+                command.BeginArguments();
+                command.AppendAtomicCast(arithmeticValue.ArithmeticBasicValueType);
+                command.AppendArgument(argument);
+                command.EndArguments();
+            }
+        }
+
+        #endregion
+
+        #region IsNaN & IsInfinity
+
+        /// <summary cref="XMath.IsNaN(double)"/>
+        public static bool IsNaN(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.IsNaN(float)"/>
+        public static bool IsNaN(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.IsInfinity(double)"/>
+        public static bool IsInfinity(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.IsInfinity(float)"/>
+        public static bool IsInfinity(float value) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        #region Rcp
+
+        /// <summary cref="XMath.Rcp(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Rcp(double value) =>
+            1.0 / value;
+
+        /// <summary cref="XMath.Rcp(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Rcp(float value) =>
+            1.0f / value;
+
+        #endregion
+
+        #region Rem
+
+        /// <summary cref="XMath.Rem(double, double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Rem(double x, double y) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Rem(float, float)"/>
+        public static float Rem(float x, float y) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        #region Sqrt
+
+        /// <summary cref="XMath.Sqrt(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sqrt(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Sqrt(float)" />
+        public static float Sqrt(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Rsqrt(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Rsqrt(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Rsqrt(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Rsqrt(float value) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        #region Floor & Ceiling
+
+        /// <summary cref="XMath.Floor(double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Floor(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Floor(float)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Floor(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Ceiling(double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Ceiling(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Ceiling(float)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Ceiling(float value) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        #region Trig
+
+        /// <summary cref="XMath.Sin(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sin(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Sin(float)" />
+        public static float Sin(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Sinh(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sinh(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Sinh(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Sinh(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Asin(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Asin(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Asin(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Asin(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Cos(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Cos(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Cos(float)" />
+        public static float Cos(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Cosh(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Cosh(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Cosh(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Cosh(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Acos(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Acos(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Acos(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Acos(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Tan(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Tan(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Tan(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Tan(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Tanh(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Tanh(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Tanh(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Tanh(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Atan(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Atan(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Atan(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Atan(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Atan2(double, double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Atan2(double y, double x) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Atan2(float, float)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Atan2(float y, float x) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        #region Pow
+
+        /// <summary cref="XMath.Pow(double, double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Pow(double @base, double exp) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Pow(float, float)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Pow(float @base, float exp) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Exp(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Exp(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Exp(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Exp(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Exp2(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Exp2(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Exp2(float)" />
+        public static float Exp2(float value) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        #region Log
+
+        /// <summary cref="XMath.Log(double, double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log(double value, double newBase) =>
+            XMath.Log(value) * Rcp(XMath.Log(newBase));
+
+        /// <summary cref="XMath.Log(float, float)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Log(float value, float newBase) =>
+            XMath.Log(value) * Rcp(XMath.Log(newBase));
+
+        /// <summary cref="XMath.Log(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Log(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Log(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Log10(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log10(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Log10(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Log10(float value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Log2(double)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log2(double value) =>
+            throw new NotImplementedException();
+
+        /// <summary cref="XMath.Log2(float)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Log2(float value) =>
+            throw new NotImplementedException();
+
+        #endregion
+    }
+}

--- a/Src/ILGPU.Algorithms/CL/CLMath.cs
+++ b/Src/ILGPU.Algorithms/CL/CLMath.cs
@@ -24,7 +24,7 @@ namespace ILGPU.Algorithms.CL
 
         /// <summary>
         /// Generates intrinsic math instructions for the following kinds:
-        /// Rcp, Sqrt, Sin, Cos, Exp2, Log2, IsInf, IsNaN
+        /// Rcp
         /// </summary>
         /// <param name="backend">The current backend.</param>
         /// <param name="codeGenerator">The code generator.</param>


### PR DESCRIPTION
Implements `CLMath` to try to resolve missing `Rcp` and `Log(x, y)` implementations on OpenCL.

However, this is currently blocked by https://github.com/m4rs-mt/ILGPU/issues/83