### PR TITLE
Fixed edge cases for Trig/Log/Exp XMath functions

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
@@ -56,6 +56,10 @@ namespace ILGPU.Algorithms.Tests
             for (var x = <#= start #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
 
+            var edgeCases = new <#= function.DataType #>[] { 0.0<#= function.ValueSuffix #>, <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+                inputValues.Add(edgeCases[x]);
+
             var inputArray = inputValues.ToArray();
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
             using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
@@ -92,6 +96,10 @@ namespace ILGPU.Algorithms.Tests
             var inputValues = new List<<#= function.DataType #>>();
             for (var x = <#= start #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
+
+            var edgeCases = new <#= function.DataType #>[] { 0.0<#= function.ValueSuffix #>, <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+                inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
@@ -132,6 +140,15 @@ namespace ILGPU.Algorithms.Tests
                 for (var y = <#= start.ToString("F1") #><#= function.ValueSuffix #>; y <= <#= end #><#= function.ValueSuffix #>; y += <#= step #><#= function.ValueSuffix #>)
                 {
                     inputValues.Add(new XMathTuple<<#= function.DataType #>>(x, y));
+                }
+            }
+
+            var edgeCases = new <#= function.DataType #>[] { 0.0<#= function.ValueSuffix #>, <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+            {
+                for (var y = 0; y < edgeCases.Length; y++)
+                {
+                    inputValues.Add(new XMathTuple<<#= function.DataType #>>(edgeCases[x], edgeCases[y]));
                 }
             }
 

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
@@ -96,6 +96,10 @@ namespace ILGPU.Algorithms.Tests
             for (var x = <#= start.ToString("F1") #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
 
+            var edgeCases = new <#= function.DataType #>[] { <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+                inputValues.Add(edgeCases[x]);
+
             var inputArray = inputValues.ToArray();
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
             using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
@@ -132,6 +136,10 @@ namespace ILGPU.Algorithms.Tests
             var inputValues = new List<<#= function.DataType #>>();
             for (var x = <#= start.ToString("F1") #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
+
+            var edgeCases = new <#= function.DataType #>[] { <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+                inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
@@ -42,6 +42,10 @@ namespace ILGPU.Algorithms.Tests
             for (var x = <#= start #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
 
+            var edgeCases = new <#= function.DataType #>[] { 0.0<#= function.ValueSuffix #>, <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+                inputValues.Add(edgeCases[x]);
+
             var inputArray = inputValues.ToArray();
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
             using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Sqrt.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Sqrt.tt
@@ -48,6 +48,10 @@ namespace ILGPU.Algorithms.Tests
             for (var x = <#= start.ToString("F1") #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
 
+            var edgeCases = new <#= function.DataType #>[] { <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+                inputValues.Add(edgeCases[x]);
+
             var inputArray = inputValues.ToArray();
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
             using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
@@ -84,6 +88,10 @@ namespace ILGPU.Algorithms.Tests
             var inputValues = new List<<#= function.DataType #>>();
             for (var x = <#= start #><#= function.ValueSuffix #>; x <= <#= end #><#= function.ValueSuffix #>; x += <#= step #><#= function.ValueSuffix #>)
                 inputValues.Add(x);
+
+            var edgeCases = new <#= function.DataType #>[] { <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+                inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
@@ -64,6 +64,7 @@ namespace ILGPU.Algorithms.Tests
             var inputArray =
                 Enumerable.Range(<#= startRange #>, <#= endRange - startRange + 1 #>)<#= function.Condition #>
                 <#= function.Projection #>
+                .Concat(new <#= function.DataType #>[] { 0.0<#= function.ValueSuffix #>, <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity }) // Edge cases
                 .ToArray();
 
             using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
@@ -104,6 +105,15 @@ namespace ILGPU.Algorithms.Tests
                 for (var y = <#= start.ToString("F1") #><#= function.ValueSuffix #>; y <= <#= end #><#= function.ValueSuffix #>; y += <#= step #><#= function.ValueSuffix #>)
                 {
                     inputValues.Add(new XMathTuple<<#= function.DataType #>>(x, y));
+                }
+            }
+
+            var edgeCases = new <#= function.DataType #>[] { 0.0<#= function.ValueSuffix #>, <#= function.DataType #>.NaN, <#= function.DataType #>.PositiveInfinity, <#= function.DataType #>.NegativeInfinity };
+            for (var x = 0; x < edgeCases.Length; x++)
+            {
+                for (var y = 0; y < edgeCases.Length; y++)
+                {
+                    inputValues.Add(new XMathTuple<<#= function.DataType #>>(edgeCases[x], edgeCases[y]));
                 }
             }
 

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.cs
@@ -35,8 +35,22 @@ namespace ILGPU.Algorithms.Tests
             public FloatPrecisionComparer(uint decimalPlaces) =>
                 Margin = MathF.Pow(10, -decimalPlaces);
 
-            public override bool Equals(float x, float y) =>
-                Math.Abs(x - y) < Margin;
+            public override bool Equals(float x, float y)
+            {
+                if ((float.IsNaN(x) && float.IsNaN(y)) ||
+                    (float.IsPositiveInfinity(x) && float.IsPositiveInfinity(y)) ||
+                    (float.IsNegativeInfinity(x) && float.IsNegativeInfinity(y)))
+                {
+                    return true;
+                }
+                else if ((float.IsPositiveInfinity(x) && float.IsNegativeInfinity(y)) ||
+                    (float.IsNegativeInfinity(x) && float.IsPositiveInfinity(y)))
+                {
+                    return false;
+                }
+
+                return Math.Abs(x - y) < Margin;
+            }
 
             public override int GetHashCode(float obj) =>
                 obj.GetHashCode();
@@ -53,8 +67,22 @@ namespace ILGPU.Algorithms.Tests
             public DoublePrecisionComparer(uint decimalPlaces) =>
                 Margin = Math.Pow(10, -decimalPlaces);
 
-            public override bool Equals(double x, double y) =>
-                Math.Abs(x - y) < Margin;
+            public override bool Equals(double x, double y)
+            {
+                if ((double.IsNaN(x) && double.IsNaN(y)) ||
+                    (double.IsPositiveInfinity(x) && double.IsPositiveInfinity(y)) ||
+                    (double.IsNegativeInfinity(x) && double.IsNegativeInfinity(y)))
+                {
+                    return true;
+                }
+                else if ((double.IsPositiveInfinity(x) && double.IsNegativeInfinity(y)) ||
+                    (double.IsNegativeInfinity(x) && double.IsPositiveInfinity(y)))
+                {
+                    return false;
+                }
+
+                return Math.Abs(x - y) < Margin;
+            }
 
             public override int GetHashCode(double obj) =>
                 obj.GetHashCode();
@@ -73,6 +101,13 @@ namespace ILGPU.Algorithms.Tests
 
             public override bool Equals(float x, float y)
             {
+                if ((float.IsNaN(x) && float.IsNaN(y)) ||
+                    (float.IsPositiveInfinity(x) && float.IsPositiveInfinity(y)) ||
+                    (float.IsNegativeInfinity(x) && float.IsNegativeInfinity(y)))
+                {
+                    return true;
+                }
+
                 var diff = Math.Abs(x - y);
 
                 if (diff == 0)
@@ -101,6 +136,13 @@ namespace ILGPU.Algorithms.Tests
 
             public override bool Equals(double x, double y)
             {
+                if ((double.IsNaN(x) && double.IsNaN(y)) ||
+                    (double.IsPositiveInfinity(x) && double.IsPositiveInfinity(y)) ||
+                    (double.IsNegativeInfinity(x) && double.IsNegativeInfinity(y)))
+                {
+                    return true;
+                }
+
                 var diff = Math.Abs(x - y);
 
                 if (diff == 0)

--- a/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
@@ -22,7 +22,11 @@ var unaryMathFunctions = new ValueTuple<string, Type, string, string>[]
         UnaryMathFunctions[18], // Rcp
         UnaryMathFunctions[19], // Rcp
     };
-var binaryMathFunctions = BinaryMathFunctions;
+var binaryMathFunctions = new ValueTuple<string, Type, string, string>[]
+    {
+        BinaryMathFunctions[6], // Log
+        BinaryMathFunctions[7], // Log
+    };
 #>
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;

--- a/Src/ILGPU.Algorithms/CL/CLMath.cs
+++ b/Src/ILGPU.Algorithms/CL/CLMath.cs
@@ -308,13 +308,77 @@ namespace ILGPU.Algorithms.CL
 
         /// <summary cref="XMath.Log(double, double)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Log(double value, double newBase) =>
-            XMath.Log(value) * Rcp(XMath.Log(newBase));
+        public static double Log(double value, double newBase)
+        {
+            if (value < 0.0 ||
+                newBase < 0.0 ||
+                (value != 1.0 && newBase == 0.0) ||
+                (value != 1.0 && newBase == double.PositiveInfinity) ||
+                XMath.IsNaN(value) ||
+                XMath.IsNaN(newBase) ||
+                newBase == 1.0)
+            {
+                return double.NaN;
+            }
+
+            if (value == 0.0)
+            {
+                if (0.0 < newBase && newBase < 1.0)
+                    return double.PositiveInfinity;
+                else if (newBase > 1.0)
+                    return double.NegativeInfinity;
+            }
+
+            if (value == double.PositiveInfinity)
+            {
+                if (0.0 < newBase && newBase < 1.0)
+                    return double.NegativeInfinity;
+                else if (newBase > 1.0)
+                    return double.PositiveInfinity;
+            }
+
+            if (value == 1.0 && (newBase == 0.0 || newBase == double.PositiveInfinity))
+                return 0.0;
+
+            return XMath.Log(value) * XMath.Rcp(XMath.Log(newBase));
+        }
 
         /// <summary cref="XMath.Log(float, float)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Log(float value, float newBase) =>
-            XMath.Log(value) * Rcp(XMath.Log(newBase));
+        public static float Log(float value, float newBase)
+        {
+            if (value < 0.0f ||
+                newBase < 0.0f ||
+                (value != 1.0f && newBase == 0.0f) ||
+                (value != 1.0f && newBase == float.PositiveInfinity) ||
+                XMath.IsNaN(value) ||
+                XMath.IsNaN(newBase) ||
+                newBase == 1.0f)
+            {
+                return float.NaN;
+            }
+
+            if (value == 0.0f)
+            {
+                if (0.0f < newBase && newBase < 1.0f)
+                    return float.PositiveInfinity;
+                else if (newBase > 1.0f)
+                    return float.NegativeInfinity;
+            }
+
+            if (value == float.PositiveInfinity)
+            {
+                if (0.0f < newBase && newBase < 1.0f)
+                    return float.NegativeInfinity;
+                else if (newBase > 1.0f)
+                    return float.PositiveInfinity;
+            }
+
+            if (value == 1.0f && (newBase == 0.0f || newBase == float.PositiveInfinity))
+                return 0.0f;
+
+            return XMath.Log(value) * XMath.Rcp(XMath.Log(newBase));
+        }
 
         /// <summary cref="XMath.Log(double)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Src/ILGPU.Algorithms/PTX/PTXMath.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXMath.cs
@@ -185,6 +185,13 @@ namespace ILGPU.Algorithms.PTX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Asin(double value)
         {
+            if (XMath.IsNaN(value) ||
+                value < -1.0 ||
+                value > 1.0)
+            {
+                return double.NaN;
+            }
+
             if (value == 1.0)
                 return XMath.PIHalfD;
             else if (value == -1.0)
@@ -198,6 +205,13 @@ namespace ILGPU.Algorithms.PTX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Asin(float value)
         {
+            if (XMath.IsNaN(value) ||
+                value < -1.0f ||
+                value > 1.0f)
+            {
+                return float.NaN;
+            }
+
             if (value == 1.0f)
                 return XMath.PIHalf;
             else if (value == -1.0f)
@@ -250,6 +264,13 @@ namespace ILGPU.Algorithms.PTX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Tanh(double value)
         {
+            if (XMath.IsNaN(value))
+                return value;
+            else if (value == double.PositiveInfinity)
+                return 1.0;
+            else if (value == double.NegativeInfinity)
+                return -1.0;
+
             var exp = Exp(2.0 * value);
             var denominator = XMath.Rcp(exp + 1.0);
             return (exp - 1.0) * denominator;
@@ -259,6 +280,13 @@ namespace ILGPU.Algorithms.PTX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Tanh(float value)
         {
+            if (XMath.IsNaN(value))
+                return value;
+            else if (value == float.PositiveInfinity)
+                return 1.0f;
+            else if (value == float.NegativeInfinity)
+                return -1.0f;
+
             var exp = Exp(2.0f * value);
             var denominator = XMath.Rcp(exp + 1.0f);
             return (exp - 1.0f) * denominator;
@@ -323,13 +351,77 @@ namespace ILGPU.Algorithms.PTX
 
         /// <summary cref="XMath.Log(double, double)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Log(double value, double newBase) =>
-            Log(value) * XMath.Rcp(Log(newBase));
+        public static double Log(double value, double newBase)
+        {
+            if (value < 0.0 ||
+                newBase < 0.0 ||
+                (value != 1.0 && newBase == 0.0) ||
+                (value != 1.0 && newBase == double.PositiveInfinity) ||
+                XMath.IsNaN(value) ||
+                XMath.IsNaN(newBase) ||
+                newBase == 1.0)
+            {
+                return double.NaN;
+            }
+
+            if (value == 0.0)
+            {
+                if (0.0 < newBase && newBase < 1.0)
+                    return double.PositiveInfinity;
+                else if (newBase > 1.0)
+                    return double.NegativeInfinity;
+            }
+
+            if (value == double.PositiveInfinity)
+            {
+                if (0.0 < newBase && newBase < 1.0)
+                    return double.NegativeInfinity;
+                else if (newBase > 1.0)
+                    return double.PositiveInfinity;
+            }
+
+            if (value == 1.0 && (newBase == 0.0 || newBase == double.PositiveInfinity))
+                return 0.0;
+
+            return Log(value) * XMath.Rcp(Log(newBase));
+        }
 
         /// <summary cref="XMath.Log(float, float)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Log(float value, float newBase) =>
-            Log(value) * XMath.Rcp(Log(newBase));
+        public static float Log(float value, float newBase)
+        {
+            if (value < 0.0f ||
+                newBase < 0.0f ||
+                (value != 1.0f && newBase == 0.0f) ||
+                (value != 1.0f && newBase == float.PositiveInfinity) ||
+                XMath.IsNaN(value) ||
+                XMath.IsNaN(newBase) ||
+                newBase == 1.0f)
+            {
+                return float.NaN;
+            }
+
+            if (value == 0.0f)
+            {
+                if (0.0f < newBase && newBase < 1.0f)
+                    return float.PositiveInfinity;
+                else if (newBase > 1.0f)
+                    return float.NegativeInfinity;
+            }
+
+            if (value == float.PositiveInfinity)
+            {
+                if (0.0f < newBase && newBase < 1.0f)
+                    return float.NegativeInfinity;
+                else if (newBase > 1.0f)
+                    return float.PositiveInfinity;
+            }
+
+            if (value == 1.0f && (newBase == 0.0f || newBase == float.PositiveInfinity))
+                return 0.0f;
+
+            return Log(value) * XMath.Rcp(Log(newBase));
+        }
 
         /// <summary cref="XMath.Log(double)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Src/ILGPU.Algorithms/XMath.cs
+++ b/Src/ILGPU.Algorithms/XMath.cs
@@ -132,6 +132,11 @@ namespace ILGPU.Algorithms
         public const float PIFourth = PI / 4.0f;
 
         /// <summary>
+        /// The PI/4 constant.
+        /// </summary>
+        public const double PIFourthD = PID / 4.0;
+
+        /// <summary>
         /// The 1/PI constant.
         /// </summary>
         public const float OneOverPI = 1.0f / PI;

--- a/Src/ILGPU.Algorithms/XMath/Cordic.Log.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.Log.tt
@@ -34,6 +34,14 @@ namespace ILGPU.Algorithms
             /// <returns>The exponent of a input value raised to base e</returns>
             public static <#= operation.DataType #> Log(<#= operation.DataType #> value)
             {
+                // Deal with edge cases
+                if (IsNaN(value) || value == <#= operation.DataType #>.PositiveInfinity)
+                    return value;
+                if (value == 0.0<#= operation.ValueSuffix #>)
+                    return <#= operation.DataType #>.NegativeInfinity;
+                if (value < 0.0<#= operation.ValueSuffix #>)
+                    return <#= operation.DataType #>.NaN;
+
                 // The exponential function is related to hyperbolic functions with the identity:
                 //  exp(x) = cosh(x) + sinh(x)
                 //

--- a/Src/ILGPU.Algorithms/XMath/Cordic.Pow.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.Pow.tt
@@ -34,6 +34,12 @@ namespace ILGPU.Algorithms
             /// <returns>The number e raised to the specified power</returns>
             public static <#= operation.DataType #> Exp(<#= operation.DataType #> value)
             {
+                // Deal with edge cases
+                if (IsNaN(value) || value == <#= operation.DataType #>.PositiveInfinity)
+                    return value;
+                if (value == <#= operation.DataType #>.NegativeInfinity)
+                    return 0.0<#= operation.ValueSuffix #>;
+
                 // Deal with negative exponents
                 if (value < 0)
                     return 1.0<#= operation.ValueSuffix #> / Exp(-1.0<#= operation.ValueSuffix #> * value);

--- a/Src/ILGPU.Algorithms/XMath/Cordic.Trig.tt
+++ b/Src/ILGPU.Algorithms/XMath/Cordic.Trig.tt
@@ -61,6 +61,14 @@ namespace ILGPU.Algorithms
             /// <param name="cos">The cosine result</param>
             public static void SinCos(<#= operation.DataType #> radians, out <#= operation.DataType #> sin, out <#= operation.DataType #> cos)
             {
+                // Deal with edge cases
+                if (IsNaN(radians) || IsInfinity(radians))
+                {
+                    sin = <#= operation.DataType #>.NaN;
+                    cos = <#= operation.DataType #>.NaN;
+                    return;
+                }
+
                 // Ensure that the radians are between [-PI, PI]
                 radians = RangeLimit(radians);
 
@@ -102,6 +110,10 @@ namespace ILGPU.Algorithms
                 // second or third quadrant, and without correcting for the "gain" from
                 // rotations - both are redudant multiplications for our calculation.
 
+                // Deal with edge cases
+                if (IsNaN(radians) || IsInfinity(radians))
+                    return <#= operation.DataType #>.NaN;
+
                 // Ensure that the radians are between [-PI, PI]
                 radians = RangeLimit(radians);
 
@@ -130,6 +142,14 @@ namespace ILGPU.Algorithms
             /// <returns>The angle in radians</returns>
             public static <#= operation.DataType #> Atan(<#= operation.DataType #> value)
             {
+                // Deal with edge cases
+                if (IsNaN(value))
+                    return <#= operation.DataType #>.NaN;
+                else if (value == <#= operation.DataType #>.PositiveInfinity)
+                    return PIHalf<#= operation.XMathSuffix #>;
+                else if (value == <#= operation.DataType #>.NegativeInfinity)
+                    return -PIHalf<#= operation.XMathSuffix #>;
+
                 // Apply <#= operation.Iterations #> iterations.
                 return VectorIterations(value);
             }
@@ -144,6 +164,18 @@ namespace ILGPU.Algorithms
             /// <returns>The angle in radians</returns>
             public static <#= operation.DataType #> Atan2(<#= operation.DataType #> y, <#= operation.DataType #> x)
             {
+                // Deal with edge cases
+                if (IsNaN(x) || IsNaN(y))
+                    return <#= operation.DataType #>.NaN;
+                else if ((x == <#= operation.DataType #>.NegativeInfinity && y == <#= operation.DataType #>.PositiveInfinity))
+                    return 3.0<#= operation.ValueSuffix #> * PIFourth<#= operation.XMathSuffix #>;
+                else if ((x == <#= operation.DataType #>.NegativeInfinity && y == <#= operation.DataType #>.NegativeInfinity))
+                    return -3.0<#= operation.ValueSuffix #> * PIFourth<#= operation.XMathSuffix #>;
+                else if ((x == <#= operation.DataType #>.PositiveInfinity && y == <#= operation.DataType #>.PositiveInfinity))
+                    return PIFourth<#= operation.XMathSuffix #>;
+                else if ((x == <#= operation.DataType #>.PositiveInfinity && y == <#= operation.DataType #>.NegativeInfinity))
+                    return -PIFourth<#= operation.XMathSuffix #>;
+
                 // Tranform to equivalent Atan calculation, as defined in:
                 // https://en.wikipedia.org/wiki/Atan2
                 if (x > 0)


### PR DESCRIPTION
Fixes some of the issues with https://github.com/m4rs-mt/ILGPU.Algorithms/issues/16
NOTE: the `Pow` function is still not fixed, and does not deal with negative 'base'. This is a known limitation of the way we calculate `Pow`.

Requires https://github.com/m4rs-mt/ILGPU/pull/91 and https://github.com/m4rs-mt/ILGPU/pull/92