### PR TITLE
Added simple histogram algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,8 @@ ModelManifest.xml
 # Ignore specific template outputs
 Src/ILGPU.Algorithms/AlgorithmContextMappings.cs
 Src/ILGPU.Algorithms/CL/CLContext.Generated.cs
+Src/ILGPU.Algorithms/HistogramLaunchers.cs
+Src/ILGPU.Algorithms/HistogramOperations.cs
 Src/ILGPU.Algorithms/IL/ILContext.Generated.cs
 Src/ILGPU.Algorithms/PTX/PTXContext.Generated.cs
 Src/ILGPU.Algorithms/RadixSortOperations.cs
@@ -263,6 +265,7 @@ Src/ILGPU.Algorithms/XMath/Cordic.Trig.cs
 
 # Generated test source files
 Src/ILGPU.Algorithms.Tests/Generic/ConfigurationBase.cs
+Src/ILGPU.Algorithms.Tests/HistogramTests.cs
 Src/ILGPU.Algorithms.Tests/XMathTests.Log.cs
 Src/ILGPU.Algorithms.Tests/XMathTests.Pow.cs
 Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.cs

--- a/Src/ILGPU.Algorithms.Tests/Configurations.txt
+++ b/Src/ILGPU.Algorithms.Tests/Configurations.txt
@@ -1,1 +1,2 @@
-﻿XMathTests: Debug, Release
+﻿HistogramTests: Debug, Release
+XMathTests: Debug, Release

--- a/Src/ILGPU.Algorithms.Tests/HistogramTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/HistogramTests.tt
@@ -1,0 +1,325 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                Copyright(c) 2016-2018 ILGPU Lightning Project
+//                                www.ilgpu.net
+//
+// File: HistogramTests.tt/HistogramTests.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details
+// -----------------------------------------------------------------------------
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="../../ILGPU/Src/ILGPU/TypeInformation.tt"#>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+using ILGPU.Algorithms.HistogramOperations;
+using ILGPU.Runtime;
+using ILGPU.Tests;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+<#
+var incrementTypes = AtomicNumericTypes;
+var inputTypes = NumericTypes;
+#>
+namespace ILGPU.Algorithms.Tests
+{
+    public abstract partial class HistogramTests : TestBase
+    {
+        protected HistogramTests(ITestOutputHelper output, TestContext testContext)
+            : base(output, testContext)
+        { }
+
+        #region Initialize Helpers
+
+<# foreach (var inputType in inputTypes) { #>
+        <#= inputType.Type #>[] InitializeInput1D_<#= inputType.Name #>(int length)
+        {
+            return Enumerable.Range(1, length).Select(x => (<#= inputType.Type #>)x).ToArray();
+        }
+
+        [SuppressMessage(
+            "Performance",
+            "CA1814:Prefer jagged arrays over multidimensional")]
+        <#= inputType.Type #>[,] InitializeInput2D_<#= inputType.Name #>(int length)
+        {
+            var inputArray = new <#= inputType.Type #>[length, length];
+            var values = Enumerable.Range(1, length * length).GetEnumerator();
+
+            for (var i = 0; i < length; i++)
+            {
+                for (var j = 0; j < length; j++)
+                {
+                    values.MoveNext();
+                    inputArray[i, j] = (<#= inputType.Type #>)values.Current;
+                }
+            }
+
+            return inputArray;
+        }
+
+        [SuppressMessage(
+            "Performance",
+            "CA1814:Prefer jagged arrays over multidimensional")]
+        <#= inputType.Type #>[,,] InitializeInput3D_<#= inputType.Name #>(int length)
+        {
+            var inputArray = new <#= inputType.Type #>[length, length, length];
+            var values = Enumerable.Range(1, length * length * length).GetEnumerator();
+
+            for (var i = 0; i < length; i++)
+            {
+                for (var j = 0; j < length; j++)
+                {
+                    for (var k = 0; k < length; k++)
+                    {
+                        values.MoveNext();
+                        inputArray[i, j, k] = (<#= inputType.Type #>)values.Current;
+                    }
+                }
+            }
+
+            return inputArray;
+        }
+
+<# } #>
+        void ApplyHistogram1D<
+            T,
+            TBinType,
+            TLocator,
+            TIncrementor>(
+                TBinType[] histogram,
+                T[] values,
+                out int[] expectedOverflow)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TLocator : struct, IComputeSingleBinOperation<T>
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+        {
+            var numBins = histogram.Length;
+            TLocator operation = default;
+            TIncrementor increment = default;
+            var histogramOverflow = false;
+
+            foreach (var value in values)
+            {
+                var binIdx = operation.ComputeHistogramBin(value, numBins);
+                increment.Increment(ref histogram[binIdx], out var incrementOverflow);
+                histogramOverflow |= incrementOverflow;
+            }
+
+            expectedOverflow = new[] { histogramOverflow ? 1 : 0 };
+        }
+
+        [SuppressMessage(
+            "Performance",
+            "CA1814:Prefer jagged arrays over multidimensional")]
+        void ApplyHistogram2D<
+            T,
+            TBinType,
+            TLocator,
+            TIncrementor>(
+                TBinType[] histogram,
+                T[,] values,
+                out int[] expectedOverflow)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TLocator : struct, IComputeSingleBinOperation<T>
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+        {
+            var numBins = histogram.Length;
+            TLocator operation = default;
+            TIncrementor increment = default;
+            var histogramOverflow = false;
+
+            foreach (var value in values)
+            {
+                var binIdx = operation.ComputeHistogramBin(value, numBins);
+                increment.Increment(ref histogram[binIdx], out var incrementOverflow);
+                histogramOverflow |= incrementOverflow;
+            }
+
+            expectedOverflow = new[] { histogramOverflow ? 1 : 0 };
+        }
+
+        [SuppressMessage(
+            "Performance",
+            "CA1814:Prefer jagged arrays over multidimensional")]
+        void ApplyHistogram3D<
+            T,
+            TBinType,
+            TLocator,
+            TIncrementor>(
+                TBinType[] histogram,
+                T[,,] values,
+                out int[] expectedOverflow)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TLocator : struct, IComputeSingleBinOperation<T>
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+        {
+            var numBins = histogram.Length;
+            TLocator operation = default;
+            TIncrementor increment = default;
+            var histogramOverflow = false;
+
+            foreach (var value in values)
+            {
+                var binIdx = operation.ComputeHistogramBin(value, numBins);
+                increment.Increment(ref histogram[binIdx], out var incrementOverflow);
+                histogramOverflow |= incrementOverflow;
+            }
+
+            expectedOverflow = new[] { histogramOverflow ? 1 : 0 };
+        }
+
+        #endregion
+
+        #region Histogram Modulo Operations
+
+<# foreach (var inputType in inputTypes) { #>
+        internal readonly struct ModuloBin<#= inputType.Name #>Operation
+            : IComputeSingleBinOperation<<#= inputType.Type #>>
+        {
+            public int ComputeHistogramBin(<#= inputType.Type #> value, int numBins) =>
+<#      if (inputType.IsFloat) { #>
+                (int)XMath.Abs(XMath.Rem(value, numBins));
+<#      } else { #>
+                (int)XMath.Abs(value % (uint)numBins);
+<#      } #>
+        };
+
+<# } #>
+        #endregion
+
+<# for (int i = 1; i <= 3; ++i) { #>
+        #region Histogram <#= i #>D Tests
+
+<#      foreach (var inputType in inputTypes) { #>
+<#          foreach (var binType in incrementTypes) { #>
+        [Theory]
+        [InlineData(64, 1024)]
+        [InlineData(256, 1024)]
+        public void Histogram<#= i #>D_CreateBin<#= binType.Name #>From<#= inputType.Name #>(
+            int numBins,
+            int length)
+        {
+<#              if (i > 1) { #>
+            length = (int)System.Math.Pow(length, 1.0 / <#= i #>.0);
+<#              } #>
+
+            var inputArray = InitializeInput<#= i #>D_<#= inputType.Name #>(length);
+            var expected = new <#= binType.Type #>[numBins];
+            ApplyHistogram<#= i #>D<
+                <#= inputType.Type #>,
+                <#= binType.Type #>,
+                ModuloBin<#= inputType.Name #>Operation,
+                HistogramIncrement<#= binType.Name #>>(
+                    expected,
+                    inputArray,
+                    out var expectedOverflow);
+
+            using var input = Accelerator.Allocate<<#= inputType.Type #>>(
+                new Index<#= i #>(length));
+            input.CopyFrom(
+                inputArray,
+                Index<#= i #>.Zero,
+                Index<#= i #>.Zero,
+                input.Extent);
+
+            using var histogram = Accelerator.Allocate<<#= binType.Type #>>(numBins);
+            histogram.MemSetToZero();
+
+            using var histogramOverflow = Accelerator.Allocate<int>(1);
+            histogramOverflow.MemSetToZero();
+
+            Accelerator.Synchronize();
+            Accelerator.Histogram<#= i > 1 ? $"{i}D" : "" #><
+                <#= inputType.Type #>,
+                ModuloBin<#= inputType.Name #>Operation>(
+                    Accelerator.DefaultStream,
+                    input.View,
+                    histogram.View,
+                    histogramOverflow.View);
+            Accelerator.Synchronize();
+
+            Verify(histogram, expected);
+            Verify(histogramOverflow, expectedOverflow);
+        }
+
+<#              /*  NB: Disabled overflow test for floats as they are not reliable  */ #>
+<#              if (!binType.IsFloat) { #>
+        [Fact]
+        public void HistogramOverflow<#= i #>D_CreateBin<#= binType.Name #>From<#= inputType.Name #>()
+        {
+            var length = 32;
+            var inputArray = InitializeInput<#= i #>D_<#= inputType.Name #>(length);
+
+            // Prepare a histogram that is just about to overflow
+            var expected = new <#= binType.Type #>[]
+            {
+                <#= binType.Type #>.MaxValue - (<#= binType.Type #>)Math.Pow(length, <#= i #>) - 1
+            };
+            ApplyHistogram<#= i #>D<
+                <#= inputType.Type #>,
+                <#= binType.Type #>,
+                ModuloBin<#= inputType.Name #>Operation,
+                HistogramIncrement<#= binType.Name #>>(
+                    expected,
+                    inputArray,
+                    out var expectedOverflow1);
+
+            using var input = Accelerator.Allocate<<#= inputType.Type #>>(new Index<#= i #>(length));
+            input.CopyFrom(
+                inputArray,
+                Index<#= i #>.Zero,
+                Index<#= i #>.Zero,
+                input.Extent);
+
+            using var histogram = Accelerator.Allocate<<#= binType.Type #>>(
+                expected.Length);
+            histogram.CopyFrom(expected, Index1.Zero, Index1.Zero, histogram.Extent);
+
+            using var histogramOverflow = Accelerator.Allocate<int>(1);
+            histogramOverflow.MemSetToZero();
+
+            // Check that the expected histogram has not yet overflowed
+            Accelerator.Synchronize();
+            Verify(histogramOverflow, expectedOverflow1);
+
+            // Apply the histogram operation one more time to generate an overflow
+            ApplyHistogram<#= i #>D<
+                <#= inputType.Type #>,
+                <#= binType.Type #>,
+                ModuloBin<#= inputType.Name #>Operation,
+                HistogramIncrement<#= binType.Name #>>(
+                    expected,
+                    inputArray,
+                    out var expectedOverflow2);
+
+            Accelerator.Histogram<#= i > 1 ? $"{i}D" : "" #><
+                <#= inputType.Type #>,
+                ModuloBin<#= inputType.Name #>Operation>(
+                    Accelerator.DefaultStream,
+                    input.View,
+                    histogram.View,
+                    histogramOverflow.View);
+            Accelerator.Synchronize();
+
+            Verify(histogram, expected);
+            Verify(histogramOverflow, expectedOverflow2);
+        }
+<#              } #>
+<#          } #>
+<#      } #>
+        #endregion
+
+<# } #>
+    }
+}

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -29,6 +29,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Histogram.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Histogram.cs</LastGenOutput>
+    </None>
+    <None Update="HistogramTests.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>HistogramTests.cs</LastGenOutput>
+    </None>
     <None Update="XMathTests.Log.tt">
       <LastGenOutput>XMathTests.Log.cs</LastGenOutput>
       <Generator>TextTemplatingFileGenerator</Generator>
@@ -56,6 +64,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Histogram.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Histogram.tt</DependentUpon>
+    </Compile>
+    <Compile Update="HistogramTests.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>HistogramTests.tt</DependentUpon>
+    </Compile>
     <Compile Update="XMathTests.Log.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/Src/ILGPU.Algorithms/HistogramExtensions.cs
+++ b/Src/ILGPU.Algorithms/HistogramExtensions.cs
@@ -1,0 +1,456 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                Copyright(c) 2016-2018 ILGPU Lightning Project
+//                                www.ilgpu.net
+//
+// File: HistogramExtensions.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details
+// -----------------------------------------------------------------------------
+using ILGPU.Algorithms.HistogramOperations;
+using ILGPU.Runtime;
+using System.Reflection;
+
+namespace ILGPU.Algorithms
+{
+    #region Delegates
+
+    /// <summary>
+    /// Represents a histogram operation on the given view.
+    /// </summary>
+    /// <typeparam name="T">The input view element type.</typeparam>
+    /// <typeparam name="TIndex">The input view index type.</typeparam>
+    /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+    /// <param name="stream">The accelerator stream.</param>
+    /// <param name="view">The input view.</param>
+    /// <param name="histogram">The histogram view to update.</param>
+    /// <param name="histogramOverflow">
+    /// Single-element view that indicates whether the histogram has overflowed.
+    /// </param>
+    public delegate void Histogram<T, TIndex, TBinType>(
+        AcceleratorStream stream,
+        ArrayView<T, TIndex> view,
+        ArrayView<TBinType> histogram,
+        ArrayView<int> histogramOverflow)
+        where T : unmanaged
+        where TBinType : unmanaged
+        where TIndex : unmanaged, IIndex, IGenericIndex<TIndex>;
+
+    /// <summary>
+    /// Represents a histogram operation on the given view.
+    /// </summary>
+    /// <typeparam name="T">The input view element type.</typeparam>
+    /// <typeparam name="TIndex">The input view index type.</typeparam>
+    /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+    /// <param name="stream">The accelerator stream.</param>
+    /// <param name="view">The input view.</param>
+    /// <param name="histogram">The histogram view to update.</param>
+    public delegate void HistogramUnchecked<T, TIndex, TBinType>(
+        AcceleratorStream stream,
+        ArrayView<T, TIndex> view,
+        ArrayView<TBinType> histogram)
+        where T : unmanaged
+        where TBinType : unmanaged
+        where TIndex : unmanaged, IIndex, IGenericIndex<TIndex>;
+
+    #endregion
+
+    /// <summary>
+    /// Contains extension methods for histogram operations.
+    /// </summary>
+    public static partial class HistogramExtensions
+    {
+        #region Histogram Helpers
+
+        /// <summary>
+        /// The delegate for the computing the histogram.
+        /// </summary>
+        /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="config">The kernel configuration to use.</param>
+        /// <param name="view">The input view.</param>
+        /// <param name="histogram">The histogram view to update.</param>
+        /// <param name="histogramOverflow">
+        /// Single-element view that indicates whether the histogram has overflowed.
+        /// </param>
+        /// <param name="paddedLength">The padded length of the input view.</param>
+        private delegate void HistogramDelegate<
+            T,
+            TBinType,
+            TIncrementor,
+            TLocator>(
+            AcceleratorStream stream,
+            KernelConfig config,
+            ArrayView<T> view,
+            ArrayView<TBinType> histogram,
+            ArrayView<int> histogramOverflow,
+            int paddedLength)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>;
+
+        /// <summary>
+        /// The delegate for the computing the histogram.
+        /// </summary>
+        /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="config">The kernel configuration to use.</param>
+        /// <param name="view">The input view.</param>
+        /// <param name="histogram">The histogram view to update.</param>
+        /// <param name="paddedLength">The padded length of the input view.</param>
+        private delegate void HistogramUncheckedDelegate<
+            T,
+            TBinType,
+            TIncrementor,
+            TLocator>(
+            AcceleratorStream stream,
+            KernelConfig config,
+            ArrayView<T> view,
+            ArrayView<TBinType> histogram,
+            int paddedLength)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>;
+
+        #endregion
+
+        #region Histogram Implementation
+
+        private static readonly MethodInfo HistogramKernelMethod =
+            typeof(HistogramExtensions).GetMethod(
+                nameof(HistogramKernel),
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+        private static readonly MethodInfo HistogramUncheckedKernelMethod =
+            typeof(HistogramExtensions).GetMethod(
+                nameof(HistogramUncheckedKernel),
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+        /// <summary>
+        /// The actual histogram kernel implementation.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="view">The input view.</param>
+        /// <param name="histogram">The histogram view to update.</param>
+        /// <param name="histogramOverflow">
+        /// Single-element view that indicates 4 the histogram has overflowed.
+        /// </param>
+        /// <param name="paddedLength">The padded length of the input view.</param>
+        internal static void HistogramKernel<
+            T,
+            TBinType,
+            TIncrementor,
+            TLocator>(
+            ArrayView<T> view,
+            ArrayView<TBinType> histogram,
+            ArrayView<int> histogramOverflow,
+            int paddedLength)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        {
+            HistogramWorkKernel<T, TBinType, TIncrementor, TLocator>(
+                view,
+                histogram,
+                out var histogramDidOverflow,
+                paddedLength);
+            Atomic.Or(ref histogramOverflow[0], histogramDidOverflow ? 1 : 0);
+        }
+
+        /// <summary>
+        /// The actual histogram kernel implementation (without overflow checking).
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="view">The input view.</param>
+        /// <param name="histogram">The histogram view to update.</param>
+        /// <param name="paddedLength">The padded length of the input view.</param>
+        internal static void HistogramUncheckedKernel<
+            T,
+            TBinType,
+            TIncrementor,
+            TLocator>(
+            ArrayView<T> view,
+            ArrayView<TBinType> histogram,
+            int paddedLength)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        {
+            HistogramWorkKernel<T, TBinType, TIncrementor, TLocator>(
+                view,
+                histogram,
+                out _,
+                paddedLength);
+        }
+
+        internal static void HistogramWorkKernel<T, TBinType, TIncrementor, TLocator>(
+            ArrayView<T> view,
+            ArrayView<TBinType> histogram,
+            out bool histogramOverflow,
+            int paddedLength)
+            where T : unmanaged
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        {
+            TLocator operation = default;
+            TIncrementor incrementOperation = default;
+
+            var gridIdx = Grid.IdxX;
+            var histogramDidOverflow = false;
+            for (
+                int i = Grid.GlobalIndex.X;
+                i < paddedLength;
+                i += GridExtensions.GridStrideLoopStride)
+            {
+                if (i < view.Length)
+                {
+                    operation.ComputeHistogramBins(
+                        view[i],
+                        histogram,
+                        incrementOperation,
+                        out var incrementDidOverflow);
+                    histogramDidOverflow |= incrementDidOverflow;
+                }
+
+                gridIdx += Grid.DimX;
+            }
+
+            histogramOverflow = histogramDidOverflow;
+        }
+
+        /// <summary>
+        /// Creates a kernel to calculate the histogram on a supplied view.
+        /// </summary>
+        /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TIndex">The input view index type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <returns>The created histogram handler.</returns>
+        public static Histogram<T, TIndex, TBinType> CreateHistogram<
+            T,
+            TIndex,
+            TBinType,
+            TIncrementor,
+            TLocator>(
+            this Accelerator accelerator)
+            where T : unmanaged
+            where TIndex : unmanaged, IIndex, IGenericIndex<TIndex>
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        {
+            var kernel = accelerator.LoadKernel<
+                HistogramDelegate<
+                    T,
+                    TBinType,
+                    TIncrementor,
+                    TLocator>>(
+                    HistogramKernelMethod.MakeGenericMethod(
+                        typeof(T),
+                        typeof(TBinType),
+                        typeof(TIncrementor),
+                        typeof(TLocator)));
+
+            return (stream, view, histogram, histogramOverflow) =>
+            {
+                var input = view.AsLinearView();
+                var (gridDim, groupDim) = accelerator.ComputeGridStrideLoopExtent(
+                       input.Length,
+                       out int numIterationsPerGroup);
+                int numVirtualGroups = gridDim * numIterationsPerGroup;
+                int lengthInformation =
+                    XMath.DivRoundUp(input.Length, groupDim) * groupDim;
+
+                kernel(
+                    stream,
+                    (gridDim, groupDim),
+                    input,
+                    histogram,
+                    histogramOverflow,
+                    lengthInformation);
+            };
+        }
+
+        /// <summary>
+        /// Creates a kernel to calculate the histogram on a supplied view
+        /// (without overflow checking).
+        /// </summary>
+        /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TIndex">The input view index type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <returns>The created histogram handler.</returns>
+        public static HistogramUnchecked<T, TIndex, TBinType> CreateHistogramUnchecked<
+            T,
+            TIndex,
+            TBinType,
+            TIncrementor,
+            TLocator>(
+            this Accelerator accelerator)
+            where T : unmanaged
+            where TIndex : unmanaged, IIndex, IGenericIndex<TIndex>
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        {
+            var kernel = accelerator.LoadKernel<
+                HistogramUncheckedDelegate<
+                    T,
+                    TBinType,
+                    TIncrementor,
+                    TLocator>>(
+                    HistogramUncheckedKernelMethod.MakeGenericMethod(
+                        typeof(T),
+                        typeof(TBinType),
+                        typeof(TIncrementor),
+                        typeof(TLocator)));
+
+            return (stream, view, histogram) =>
+            {
+                var input = view.AsLinearView();
+                var (gridDim, groupDim) = accelerator.ComputeGridStrideLoopExtent(
+                       input.Length,
+                       out int numIterationsPerGroup);
+                int numVirtualGroups = gridDim * numIterationsPerGroup;
+                int lengthInformation = XMath.DivRoundUp(input.Length, groupDim) * groupDim;
+
+                kernel(
+                    stream,
+                    (gridDim, groupDim),
+                    input,
+                    histogram,
+                    lengthInformation);
+            };
+        }
+
+        /// <summary>
+        /// Calculates the histogram on the given view.
+        /// </summary>
+        /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TIndex">The input view index type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The input view.</param>
+        /// <param name="histogram">The histogram view to update.</param>
+        /// <param name="histogramOverflow">
+        /// Single-element view that indicates whether the histogram has overflowed.
+        /// </param>
+        public static void Histogram<T, TIndex, TBinType, TIncrementor, TLocator>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView<T, TIndex> view,
+            ArrayView<TBinType> histogram,
+            ArrayView<int> histogramOverflow)
+            where T : unmanaged
+            where TIndex : unmanaged, IIndex, IGenericIndex<TIndex>
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        {
+            accelerator.CreateHistogram<T, TIndex, TBinType, TIncrementor, TLocator>()(
+                stream,
+                view,
+                histogram,
+                histogramOverflow);
+        }
+
+        /// <summary>
+        /// Calculates the histogram on the given view (without overflow checking).
+        /// </summary>
+        /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TIndex">The input view index type.</typeparam>
+        /// <typeparam name="TBinType">The histogram bin type.</typeparam>
+        /// <typeparam name="TIncrementor">
+        /// The operation to increment the value of the bin.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The input view.</param>
+        /// <param name="histogram">The histogram view to update.</param>
+        public static void HistogramUnchecked<
+            T,
+            TIndex,
+            TBinType,
+            TIncrementor,
+            TLocator>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView<T, TIndex> view,
+            ArrayView<TBinType> histogram)
+            where T : unmanaged
+            where TIndex : unmanaged, IIndex, IGenericIndex<TIndex>
+            where TBinType : unmanaged
+            where TIncrementor : struct, IIncrementOperation<TBinType>
+            where TLocator : struct, IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        {
+            accelerator.CreateHistogramUnchecked<
+                T,
+                TIndex,
+                TBinType,
+                TIncrementor,
+                TLocator>()(
+                    stream,
+                    view,
+                    histogram);
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU.Algorithms/HistogramLaunchers.tt
+++ b/Src/ILGPU.Algorithms/HistogramLaunchers.tt
@@ -1,0 +1,108 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                Copyright(c) 2016-2018 ILGPU Lightning Project
+//                                www.ilgpu.net
+//
+// File: HistogramLaunchers.tt/HistogramLaunchers.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details
+// -----------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="TypeInformation.ttinclude"#>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+using ILGPU.Algorithms.HistogramOperations;
+using ILGPU.Runtime;
+using System;
+
+<#
+var incrementTypes = AtomicNumericTypes;
+#>
+namespace ILGPU.Algorithms
+{
+    /// <summary>
+    /// Contains extension methods for histogram operations.
+    /// </summary>
+    partial class HistogramExtensions
+    {
+<# foreach (var type in incrementTypes) { #>
+        #region Histogram <#= type.Name #> Launchers
+
+<# for (int i = 1; i <= 3; ++i) { #>
+<#      var dimension = i > 1 ? $"{i}D" : ""; #>
+        /// <summary>
+        /// Calculates the histogram (<#= type.Type #>) on the given <#= i #>D view.
+        /// </summary>
+        /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The input view.</param>
+        /// <param name="histogram">The histogram view to update.</param>
+        /// <param name="histogramOverflow">
+        /// Single-element view that indicates whether the histogram has overflowed.
+        /// </param>
+<# if (type.IsUnsignedInt || type.Name.Contains("Int8")) { #>
+        [CLSCompliant(false)]
+<# } #>
+        public static void Histogram<#= dimension #><T, TLocator>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView<#= dimension #><T> view,
+            ArrayView<<#= type.Type #>> histogram,
+            ArrayView<int> histogramOverflow)
+            where T : unmanaged
+            where TLocator : struct, IComputeSingleBinOperation<T>
+        {
+            var kernel = accelerator.CreateHistogram<
+                T,
+                Index<#= i #>,
+                <#= type.Type #>,
+                HistogramIncrement<#= type.Name #>,
+                ComputeSingleBinAdapter<#= type.Name #><T, TLocator>>();
+            kernel(stream, view, histogram, histogramOverflow);
+        }
+
+<# } #>
+        /// <summary>
+        /// Adapter to convert single-bin operation into a multi-bin operation for
+        /// histograms of type <#= type.Type #>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The underlying type of the histogram operation.
+        /// </typeparam>
+        /// <typeparam name="TLocator">
+        /// The operation to compute the bin location.
+        /// </typeparam>
+        internal readonly struct ComputeSingleBinAdapter<#= type.Name #><T, TLocator>
+            : IComputeMultiBinOperation<T, <#= type.Type #>, HistogramIncrement<#= type.Name #>>
+            where T : unmanaged
+            where TLocator : struct, IComputeSingleBinOperation<T>
+        {
+            public void ComputeHistogramBins(
+                T value,
+                ArrayView<<#= type.Type #>> histogram,
+                in HistogramIncrement<#= type.Name #> incrementOperation,
+                out bool incrementOverflow)
+            {
+                TLocator locator = default;
+                var binIdx = locator.ComputeHistogramBin(value, histogram.Length);
+                incrementOperation.Increment(
+                    ref histogram[binIdx],
+                    out incrementOverflow);
+            }
+        }
+
+        #endregion
+
+<# } #>
+    }
+}

--- a/Src/ILGPU.Algorithms/HistogramOperations.tt
+++ b/Src/ILGPU.Algorithms/HistogramOperations.tt
@@ -1,0 +1,47 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                Copyright(c) 2016-2018 ILGPU Lightning Project
+//                                www.ilgpu.net
+//
+// File: HistogramOperations.tt/HistogramOperations.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details
+// -----------------------------------------------------------------------------
+
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ include file="TypeInformation.ttinclude"#>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+using System;
+
+<#
+var incrementTypes = AtomicNumericTypes;
+#>
+namespace ILGPU.Algorithms.HistogramOperations
+{
+<# foreach (var type in incrementTypes) { #>
+    /// <summary>
+    /// Represents atomically incrementing a histogram bin of type <#= type.Type #>.
+    /// </summary>
+<# if (type.IsUnsignedInt || type.Name.Contains("Int8")) { #>
+    [CLSCompliant(false)]
+<# } #>
+    public readonly struct HistogramIncrement<#= type.Name #> : IIncrementOperation<<#= type.Type #>>
+    {
+        /// <summary>
+        /// Atomically increments a histogram bin of type <#= type.Type #>.
+        /// </summary>
+        public void Increment(ref <#= type.Type #> target, out bool incrementOverflow)
+        {
+            var oldValue = Atomic.Add(ref target, 1);
+            incrementOverflow = oldValue == <#= type.Type #>.MaxValue;
+        }
+    }
+
+<# } #>
+}

--- a/Src/ILGPU.Algorithms/IHistogramOperations.cs
+++ b/Src/ILGPU.Algorithms/IHistogramOperations.cs
@@ -1,0 +1,78 @@
+﻿// -----------------------------------------------------------------------------
+//                             ILGPU.Algorithms
+//                  Copyright (c) 2020 ILGPU Algorithms Project
+//                Copyright(c) 2016-2018 ILGPU Lightning Project
+//                                www.ilgpu.net
+//
+// File: IHistogramOperation.cs
+//
+// This file is part of ILGPU and is distributed under the University of
+// Illinois Open Source License. See LICENSE.txt for details.
+// -----------------------------------------------------------------------------
+
+namespace ILGPU.Algorithms.HistogramOperations
+{
+    /// <summary>
+    /// Computes the histogram bin for a single input value.
+    /// </summary>
+    /// <typeparam name="T">The underlying type of the histogram operation.</typeparam>
+    public interface IComputeSingleBinOperation<T>
+        where T : unmanaged
+    {
+        /// <summary>
+        /// Calculates the histogram bin location for the given value.
+        /// </summary>
+        /// <param name="value">The value to map.</param>
+        /// <param name="numBins">The total  number of bins.</param>
+        /// <returns>The bin location</returns>
+        int ComputeHistogramBin(T value, int numBins);
+    }
+
+    /// <summary>
+    /// Computes and updates multiple histogram bins for a single input value.
+    /// </summary>
+    /// <typeparam name="T">The underlying type of the histogram operation.</typeparam>
+    /// <typeparam name="TBinType">The underlying type of the histogram bins.</typeparam>
+    /// <typeparam name="TIncrementor">
+    /// The operation to increment the value of the bin.
+    /// </typeparam>
+    public interface IComputeMultiBinOperation<T, TBinType, TIncrementor>
+        where T : unmanaged
+        where TBinType : unmanaged
+        where TIncrementor : struct, IIncrementOperation<TBinType>
+    {
+        /// <summary>
+        /// Calculates and updates multiple histogram bin locations for the given value.
+        /// </summary>
+        /// <param name="value">The value to map.</param>
+        /// <param name="histogram">The histogram to update.</param>
+        /// <param name="incrementOperation">
+        /// The operation used to increment the histogram.
+        /// </param>
+        /// <param name="incrementOverflow">
+        /// Indicates when the increment has overflowed.
+        /// </param>
+        void ComputeHistogramBins(
+            T value,
+            ArrayView<TBinType> histogram,
+            in TIncrementor incrementOperation,
+            out bool incrementOverflow);
+    }
+
+    /// <summary>
+    /// Increments the value in a histogram bin.
+    /// </summary>
+    /// <typeparam name="TBinType">The underlying type of the histogram bin.</typeparam>
+    public interface IIncrementOperation<TBinType>
+        where TBinType : unmanaged
+    {
+        /// <summary>
+        /// Increments the histogram bin.
+        /// </summary>
+        /// <param name="target">The bin value to update.</param>
+        /// <param name="incrementOverflow">
+        /// Indicates when the increment has overflowed.
+        /// </param>
+        void Increment(ref TBinType target, out bool incrementOverflow);
+    }
+}

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -29,6 +29,16 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>AlgorithmContextMappings.tt</DependentUpon>
     </None>
+    <None Include="HistogramLaunchers.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>HistogramLaunchers.tt</DependentUpon>
+    </None>
+    <None Include="HistogramOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>HistogramOperations.tt</DependentUpon>
+    </None>
     <None Include="RadixSortOperations.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -55,6 +65,14 @@
     <None Update="CL\CLContext.Generated.tt">
       <LastGenOutput>CLContext.Generated.cs</LastGenOutput>
       <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="HistogramLaunchers.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>HistogramLaunchers.cs</LastGenOutput>
+    </None>
+    <None Update="HistogramOperations.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>HistogramOperations.cs</LastGenOutput>
     </None>
     <None Update="IL\ILContext.Generated.tt">
       <LastGenOutput>ILContext.Generated.cs</LastGenOutput>
@@ -123,6 +141,16 @@
       <DependentUpon>CLContext.Generated.tt</DependentUpon>
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
+    </Compile>
+    <Compile Update="HistogramLaunchers.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>HistogramLaunchers.tt</DependentUpon>
+    </Compile>
+    <Compile Update="HistogramOperations.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>HistogramOperations.tt</DependentUpon>
     </Compile>
     <Compile Update="IL\ILContext.Generated.cs">
       <DependentUpon>ILContext.Generated.tt</DependentUpon>


### PR DESCRIPTION
Implements [histogram API proposal](https://github.com/m4rs-mt/ILGPU.Algorithms/issues/5) (slightly modified).
- The histogram kernel is very naive, using a single global histogram. It may need to be improved later to use sub-histograms in shared memory to improve performance.
- It supports a simple (optional) overflow detection when incrementing the histogram bin.
- It supports a histogram that maps one input value to one bin, or one input value to multiple bins.
- The histogram bin types are limited to the atomic numeric types, so it currently cannot use `Int8`, `UInt8`, `Int16` and `UInt16` bin types.

