### PR TITLE
Fixed XMath CPU unit tests by using predefined preprocessor symbols.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
                 Foreach ($line in Get-Content $file)
                 {
                   If ($line.Length -gt 90) {
-                    Write-Host "${file}:${index}: line too long ($($line.Length) > 90 characters)"
+                    Write-Host "##[error]${file}:${index}: line too long ($($line.Length) > 90 characters)"
                     $found = $true
                   }
                   $index++
@@ -58,7 +58,7 @@ jobs:
       - name: Release Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true Src
       - name: CPU Tests
-        run: dotnet test --configuration=Release ./Src/ILGPU.Algorithms.Tests.CPU
+        run: dotnet test --logger GitHubActions --configuration=Release ./Src/ILGPU.Algorithms.Tests.CPU
       - name: Create NuGet package
         if: runner.os == 'Windows'
         run: |

--- a/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
+++ b/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
@@ -16,9 +16,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
+++ b/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
+++ b/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
@@ -16,9 +16,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
@@ -16,9 +16,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/ILGPU.Algorithms.Tests/HistogramTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/HistogramTests.tt
@@ -42,7 +42,7 @@ namespace ILGPU.Algorithms.Tests
         #region Initialize Helpers
 
 <# foreach (var inputType in inputTypes) { #>
-        <#= inputType.Type #>[] InitializeInput1D_<#= inputType.Name #>(int length)
+        private static <#= inputType.Type #>[] InitializeInput1D_<#= inputType.Name #>(int length)
         {
             return Enumerable.Range(1, length).Select(x => (<#= inputType.Type #>)x).ToArray();
         }
@@ -50,7 +50,7 @@ namespace ILGPU.Algorithms.Tests
         [SuppressMessage(
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional")]
-        <#= inputType.Type #>[,] InitializeInput2D_<#= inputType.Name #>(int length)
+        private static <#= inputType.Type #>[,] InitializeInput2D_<#= inputType.Name #>(int length)
         {
             var inputArray = new <#= inputType.Type #>[length, length];
             var values = Enumerable.Range(1, length * length).GetEnumerator();
@@ -70,7 +70,7 @@ namespace ILGPU.Algorithms.Tests
         [SuppressMessage(
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional")]
-        <#= inputType.Type #>[,,] InitializeInput3D_<#= inputType.Name #>(int length)
+        private static <#= inputType.Type #>[,,] InitializeInput3D_<#= inputType.Name #>(int length)
         {
             var inputArray = new <#= inputType.Type #>[length, length, length];
             var values = Enumerable.Range(1, length * length * length).GetEnumerator();
@@ -91,7 +91,7 @@ namespace ILGPU.Algorithms.Tests
         }
 
 <# } #>
-        void ApplyHistogram1D<
+        private static void ApplyHistogram1D<
             T,
             TBinType,
             TLocator,
@@ -122,7 +122,7 @@ namespace ILGPU.Algorithms.Tests
         [SuppressMessage(
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional")]
-        void ApplyHistogram2D<
+        private static void ApplyHistogram2D<
             T,
             TBinType,
             TLocator,
@@ -153,7 +153,7 @@ namespace ILGPU.Algorithms.Tests
         [SuppressMessage(
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional")]
-        void ApplyHistogram3D<
+        private static void ApplyHistogram3D<
             T,
             TBinType,
             TLocator,

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms.Tests/ReductionExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ReductionExtensionTests.tt
@@ -203,7 +203,7 @@ namespace ILGPU.Algorithms.Tests
 
         #region Helper Methods
 
-        private T CalcValue<T>(T[] values, Func<T, T, T> func)
+        private static T CalcValue<T>(T[] values, Func<T, T, T> func)
             where T : unmanaged
         {
             T result = values[0];

--- a/Src/ILGPU.Algorithms.Tests/ReorderExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ReorderExtensionTests.tt
@@ -268,7 +268,7 @@ namespace ILGPU.Algorithms.Tests
 
         #region Helper Method
 
-        private TTarget[] CalcValues<TSource, TTarget, TTransform>(
+        private static TTarget[] CalcValues<TSource, TTarget, TTransform>(
             TSource[] input,
             Index1[] order,
             TTransform transform)

--- a/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
@@ -259,7 +259,10 @@ namespace ILGPU.Algorithms.Tests
 
         #region Helper Methods
 
-        private static T[] CalcValues<T, TFunction>(T[] values, TFunction func, ScanKind kind)
+        private static T[] CalcValues<T, TFunction>(
+            T[] values,
+            TFunction func,
+            ScanKind kind)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {

--- a/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
@@ -259,7 +259,7 @@ namespace ILGPU.Algorithms.Tests
 
         #region Helper Methods
 
-        private T[] CalcValues<T, TFunction>(T[] values, TFunction func, ScanKind kind)
+        private static T[] CalcValues<T, TFunction>(T[] values, TFunction func, ScanKind kind)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {

--- a/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
@@ -252,7 +252,10 @@ namespace ILGPU.Algorithms.Tests
             return result;
         }
 
-        private static T[] CalcValues<T, TFunction>(T[] values, TFunction func, ScanKind kind)
+        private static T[] CalcValues<T, TFunction>(
+            T[] values,
+            TFunction func,
+            ScanKind kind)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {

--- a/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
@@ -242,7 +242,7 @@ namespace ILGPU.Algorithms.Tests
         
         #region Helper Methods
 
-        private T CalcValue<T, TFunction>(T[] values, TFunction func)
+        private static T CalcValue<T, TFunction>(T[] values, TFunction func)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {
@@ -252,7 +252,7 @@ namespace ILGPU.Algorithms.Tests
             return result;
         }
 
-        private T[] CalcValues<T, TFunction>(T[] values, TFunction func, ScanKind kind)
+        private static T[] CalcValues<T, TFunction>(T[] values, TFunction func, ScanKind kind)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -12,10 +12,6 @@
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'!='net47'">
-    <DefineConstants>NETCORE</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>..\..\Bin\Release\ILGPU.Algorithms.xml</DocumentationFile>

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/Enums.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/Enums.cs
@@ -53,7 +53,7 @@ namespace ILGPU.Runtime.Cuda
         NonTranspose = 0,
         Transpose = 1,
         ConjugateTranspose = 2,
-        Hermitan = 2,
+        Hermitan = ConjugateTranspose,
         Conjugate = 3
     }
 

--- a/Src/ILGPU.Algorithms/XMath/Round.cs
+++ b/Src/ILGPU.Algorithms/XMath/Round.cs
@@ -38,7 +38,7 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [IntrinsicImplementation]
         public static float RoundAwayFromZero(float value) =>
-#if NETCORE
+#if !NETFRAMEWORK
             MathF.Round(value, MidpointRounding.AwayFromZero);
 #else
             (float)Math.Round(value, MidpointRounding.AwayFromZero);
@@ -62,7 +62,7 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [IntrinsicImplementation]
         public static float RoundToEven(float value) =>
-#if NETCORE
+#if !NETFRAMEWORK
             MathF.Round(value, MidpointRounding.ToEven);
 #else
             (float)Math.Round(value, MidpointRounding.ToEven);


### PR DESCRIPTION
Some of the XMath CPU unit tests would fail because the unit test uses `MathF.Asin` and ILGPU was using `(float)Math.Asin`.

After switching to the predefined preprocessor symbols, the issue goes away.

Depends on https://github.com/m4rs-mt/ILGPU/pull/264.