### PR TITLE
Added XMath.IEEERemainder implementation.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rem.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rem.tt
@@ -34,6 +34,17 @@ using Xunit;
             "double",
             "{0} % {1}",
             new RelativeError(0E-00, 1E-06, 0E-00)),
+
+        new RemFunction(
+            "IEEERemainder",
+            "float",
+            "MathF.IEEERemainder({0}, {1})",
+            new RelativeError(0E-00, 1E-06, 0E-00)),
+        new RemFunction(
+            "IEEERemainder",
+            "double",
+            "Math.IEEERemainder({0}, {1})",
+            new RelativeError(0E-00, 1E-06, 0E-00)),
     };
 #>
 namespace ILGPU.Algorithms.Tests

--- a/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/CL/CLContext.Generated.tt
@@ -27,10 +27,14 @@ var binaryMathFunctions = new ValueTuple<string, Type, string, string>[]
         BinaryMathFunctions[6], // Log
         BinaryMathFunctions[7], // Log
     };
-var xmathCodeGenerators = new ValueTuple<string, string>[]
+var xmathUnaryCodeGenerators = new ValueTuple<string, string>[]
     {
         ( "RoundAwayFromZero",  "round" ),
         ( "RoundToEven",        "rint" ),
+    };
+var xmathBinaryCodeGenerators = new ValueTuple<string, string>[]
+    {
+        ( "IEEERemainder", "remainder" ),
     };
 #>
 using ILGPU.Backends.OpenCL;
@@ -61,12 +65,35 @@ namespace ILGPU.Algorithms.CL
                 MathCodeGeneratorIntrinsic);
 <# } #>
 
-<# foreach (var (name, functionName) in xmathCodeGenerators) { #>
+<# foreach (var (name, functionName) in xmathUnaryCodeGenerators) { #>
             RegisterXMathCodeGenerator(
                 manager,
                 typeof(CLContext),
                 "<#= name #>",
-                "Generate<#= name #>");
+                "Generate<#= name #>",
+                typeof(float));
+            RegisterXMathCodeGenerator(
+                manager,
+                typeof(CLContext),
+                "<#= name #>",
+                "Generate<#= name #>",
+                typeof(double));
+<# } #>
+<# foreach (var (name, functionName) in xmathBinaryCodeGenerators) { #>
+            RegisterXMathCodeGenerator(
+                manager,
+                typeof(CLContext),
+                "<#= name #>",
+                "Generate<#= name #>",
+                typeof(float),
+                typeof(float));
+            RegisterXMathCodeGenerator(
+                manager,
+                typeof(CLContext),
+                "<#= name #>",
+                "Generate<#= name #>",
+                typeof(double),
+                typeof(double));
 <# } #>
 
             // Register group intrinsics
@@ -130,7 +157,10 @@ namespace ILGPU.Algorithms.CL
             statementEmitter.Finish();
         }
 
-<# foreach (var (name, functionName) in xmathCodeGenerators) { #>
+<#
+   var xmathCodeGenerators = xmathUnaryCodeGenerators.Concat(xmathBinaryCodeGenerators);
+   foreach (var (name, functionName) in xmathCodeGenerators) {
+#>
         /// <summary>
         /// Generates an intrinsic code generator for <#= name #>.
         /// </summary>

--- a/Src/ILGPU.Algorithms/CL/CLContext.cs
+++ b/Src/ILGPU.Algorithms/CL/CLContext.cs
@@ -135,29 +135,20 @@ namespace ILGPU.Algorithms.CL
         /// <param name="codeGeneratorName">
         /// The name of the code generator to register.
         /// </param>
+        /// <param name="types">The argument types for the target method.</param>
         private static void RegisterXMathCodeGenerator(
             IntrinsicImplementationManager manager,
             Type targetType,
             string functionName,
-            string codeGeneratorName)
+            string codeGeneratorName,
+            params Type[] types)
         {
             manager.RegisterMethod(
                 AlgorithmContext.XMathType.GetMethod(
                     functionName,
                     AlgorithmContext.IntrinsicBindingFlags,
                     null,
-                    new[] { typeof(float) },
-                    null),
-                new CLIntrinsic(
-                    targetType,
-                    codeGeneratorName,
-                    IntrinsicImplementationMode.GenerateCode));
-            manager.RegisterMethod(
-                AlgorithmContext.XMathType.GetMethod(
-                    functionName,
-                    AlgorithmContext.IntrinsicBindingFlags,
-                    null,
-                    new[] { typeof(double) },
+                    types,
                     null),
                 new CLIntrinsic(
                     targetType,

--- a/Src/ILGPU.Algorithms/PTX/PTXContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/PTX/PTXContext.Generated.tt
@@ -41,10 +41,14 @@ var unaryMathFunctions = UnaryMathFunctions.Where(t =>
     !hardwareMathFunctions.Any(
         t2 => t.Item1 == t2.Item1 && t.Item2 == t2.Item2));
 var binaryMathFunctions = BinaryMathFunctions;
-var xmathRedirects = new[]
+var xmathUnaryRedirects = new[]
     {
         "RoundAwayFromZero",
         "RoundToEven",
+    };
+var xmathBinaryRedirects = new[]
+    {
+        "IEEERemainder",
     };
 #>
 using ILGPU.IR.Intrinsics;
@@ -81,12 +85,35 @@ namespace ILGPU.Algorithms.PTX
                 MathCodeGeneratorIntrinsic);
 <# } #>
 
-<# foreach (var functionName in xmathRedirects) { #>
+<# foreach (var functionName in xmathUnaryRedirects) { #>
             RegisterXMathRedirect(
                 manager,
                 PTXMathType,
                 "<#= functionName #>",
-                "<#= functionName #>");
+                "<#= functionName #>",
+                typeof(float));
+            RegisterXMathRedirect(
+                manager,
+                PTXMathType,
+                "<#= functionName #>",
+                "<#= functionName #>",
+                typeof(double));
+<# } #>
+<# foreach (var functionName in xmathBinaryRedirects) { #>
+            RegisterXMathRedirect(
+                manager,
+                PTXMathType,
+                "<#= functionName #>",
+                "<#= functionName #>",
+                typeof(float),
+                typeof(float));
+            RegisterXMathRedirect(
+                manager,
+                PTXMathType,
+                "<#= functionName #>",
+                "<#= functionName #>",
+                typeof(double),
+                typeof(double));
 <# } #>
 
             // Register group intrinsics

--- a/Src/ILGPU.Algorithms/PTX/PTXContext.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXContext.cs
@@ -102,40 +102,27 @@ namespace ILGPU.Algorithms.PTX
         /// <param name="replacementName">
         /// The name of the replacement method to register.
         /// </param>
+        /// <param name="types">The argument types for the target method.</param>
         private static void RegisterXMathRedirect(
             IntrinsicImplementationManager manager,
             Type targetType,
             string functionName,
-            string replacementName)
+            string replacementName,
+            params Type[] types)
         {
             manager.RegisterMethod(
                 AlgorithmContext.XMathType.GetMethod(
                     functionName,
                     AlgorithmContext.IntrinsicBindingFlags,
                     null,
-                    new[] { typeof(float) },
+                    types,
                     null),
                 new PTXIntrinsic(
                     targetType.GetMethod(
                         replacementName,
                         AlgorithmContext.IntrinsicBindingFlags,
                         null,
-                        new[] { typeof(float) },
-                        null),
-                    IntrinsicImplementationMode.Redirect));
-            manager.RegisterMethod(
-                AlgorithmContext.XMathType.GetMethod(
-                    functionName,
-                    AlgorithmContext.IntrinsicBindingFlags,
-                    null,
-                    new[] { typeof(double) },
-                    null),
-                new PTXIntrinsic(
-                    targetType.GetMethod(
-                        replacementName,
-                        AlgorithmContext.IntrinsicBindingFlags,
-                        null,
-                        new[] { typeof(double) },
+                        types,
                         null),
                     IntrinsicImplementationMode.Redirect));
         }

--- a/Src/ILGPU.Algorithms/PTX/PTXMath.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXMath.cs
@@ -124,6 +124,37 @@ namespace ILGPU.Algorithms.PTX
             return Utilities.Select(x < 0.0f, -result, result);
         }
 
+        /// <summary cref="XMath.IEEERemainder(double, double)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double IEEERemainder(double x, double y)
+        {
+            if (y == 0.0 ||
+                XMath.IsInfinity(x) ||
+                XMath.IsNaN(x) ||
+                XMath.IsNaN(y))
+                return double.NaN;
+
+            if (XMath.IsInfinity(y))
+                return x;
+
+            return x - (y * XMath.RoundToEven(x * XMath.Rcp(y)));
+        }
+
+        /// <summary cref="XMath.IEEERemainder(float, float)"/>
+        public static float IEEERemainder(float x, float y)
+        {
+            if (y == 0.0f ||
+                XMath.IsInfinity(x) ||
+                XMath.IsNaN(x) ||
+                XMath.IsNaN(y))
+                return float.NaN;
+
+            if (XMath.IsInfinity(y))
+                return x;
+
+            return x - (y * XMath.RoundToEven(x * XMath.Rcp(y)));
+        }
+
         #endregion
 
         #region Sqrt

--- a/Src/ILGPU.Algorithms/XMath/Rem.cs
+++ b/Src/ILGPU.Algorithms/XMath/Rem.cs
@@ -9,6 +9,8 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.IR.Intrinsics;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace ILGPU.Algorithms
@@ -34,5 +36,31 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Rem(float x, float y) =>
             IntrinsicMath.CPUOnly.Rem(x, y);
+
+        /// <summary>
+        /// Computes remainder operation that complies with the IEEE 754 specification.
+        /// </summary>
+        /// <param name="x">The nominator.</param>
+        /// <param name="y">The denominator.</param>
+        /// <returns>x%y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [IntrinsicImplementation]
+        public static double IEEERemainder(double x, double y) =>
+            Math.IEEERemainder(x, y);
+
+        /// <summary>
+        /// Computes remainder operation that complies with the IEEE 754 specification.
+        /// </summary>
+        /// <param name="x">The nominator.</param>
+        /// <param name="y">The denominator.</param>
+        /// <returns>x%y.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [IntrinsicImplementation]
+        public static float IEEERemainder(float x, float y) =>
+#if NETCORE
+            MathF.IEEERemainder(x, y);
+#else
+            (float)Math.IEEERemainder(x, y);
+#endif
     }
 }


### PR DESCRIPTION
Fixes missing IEERRemainder implementation as per https://github.com/m4rs-mt/ILGPU.Algorithms/issues/43.