### PR TITLE
Register Cuda TanH intrinsic on SM_75 and higher.

### DIFF
--- a/Src/ILGPU.Algorithms/PTX/PTXContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/PTX/PTXContext.Generated.tt
@@ -17,29 +17,37 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 <#
-var hardwareMathFunctions = new ValueTuple<string, Type, string, string>[]
+var hardwareMathFunctions =
+    new ValueTuple<ValueTuple<string, Type, string, string>, string>[]
     {
-        UnaryMathFunctions[10], // IsInfinity
-        UnaryMathFunctions[11], // IsInfinity
-        UnaryMathFunctions[12], // IsNaN
-        UnaryMathFunctions[13], // IsNaN
+        ( UnaryMathFunctions[10],   null ), // IsInfinity
+        ( UnaryMathFunctions[11],   null ), // IsInfinity
+        ( UnaryMathFunctions[12],   null ), // IsNaN
+        ( UnaryMathFunctions[13],   null ), // IsNaN
 
-        UnaryMathFunctions[18], // Rcp
-        UnaryMathFunctions[19], // Rcp
+        ( UnaryMathFunctions[18],   null ), // Rcp
+        ( UnaryMathFunctions[19],   null ), // Rcp
 
-        UnaryMathFunctions[20], // Sqrt
-        UnaryMathFunctions[21], // Sqrt
+        ( UnaryMathFunctions[20],   null ), // Sqrt
+        ( UnaryMathFunctions[21],   null ), // Sqrt
 
-        UnaryMathFunctions[24], // Sin
-        UnaryMathFunctions[30], // Cos
+        ( UnaryMathFunctions[24],   null ), // Sin
+        ( UnaryMathFunctions[30],   null ), // Cos
 
-        UnaryMathFunctions[16], // Exp2
+        ( UnaryMathFunctions[16],   null ), // Exp2
 
-        UnaryMathFunctions[8], // Log2
+        ( UnaryMathFunctions[8],    null ), // Log2
+
+        ( UnaryMathFunctions[40],   "SM_75" ),  // TanH
     };
 var unaryMathFunctions = UnaryMathFunctions.Where(t =>
-    !hardwareMathFunctions.Any(
-        t2 => t.Item1 == t2.Item1 && t.Item2 == t2.Item2));
+    !hardwareMathFunctions.Any(t2 => {
+        var functionName = t.Item1;
+        var dataType = t.Item2;
+        var hardwareFunctionName = t2.Item1.Item1;
+        var hardwareDataType = t2.Item1.Item2;
+        return functionName == hardwareFunctionName && dataType == hardwareDataType;
+    }));
 var binaryMathFunctions = BinaryMathFunctions;
 var xmathUnaryRedirects = new[]
     {
@@ -51,6 +59,7 @@ var xmathBinaryRedirects = new[]
         "IEEERemainder",
     };
 #>
+using ILGPU.Backends;
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;
 
@@ -78,11 +87,29 @@ namespace ILGPU.Algorithms.PTX
                     typeof(<#= type #>)));
 <# } #>
 
-<# foreach (var (name, type, kind, basicType) in hardwareMathFunctions) { #>
+<# foreach (var ((name, type, kind, basicType), sm) in hardwareMathFunctions) { #>
+<#
+       if (string.IsNullOrWhiteSpace(sm)) {
+           // Register hardware intrinsic
+#>
             manager.RegisterUnaryArithmetic(
                 UnaryArithmeticKind.<#= kind #>,
                 BasicValueType.<#= basicType #>,
                 MathCodeGeneratorIntrinsic);
+<#
+        } else {
+            // Register software fallback first, so that it gets replaced
+            // by the specialized hardware intrinsic.
+#>
+            manager.RegisterUnaryArithmetic(
+                UnaryArithmeticKind.<#= kind #>,
+                BasicValueType.<#= basicType #>,
+                GetMathIntrinsic("<#= name #>", typeof(<#= type #>)));
+            manager.RegisterUnaryArithmetic(
+                UnaryArithmeticKind.<#= kind #>,
+                BasicValueType.<#= basicType #>,
+                GetMathCodeGeneratorIntrinsic(PTXArchitecture.<#= sm #>));
+<#      } #>
 <# } #>
 
 <# foreach (var functionName in xmathUnaryRedirects) { #>

--- a/Src/ILGPU.Algorithms/PTX/PTXContext.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXContext.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+using ILGPU.Backends;
 using ILGPU.Backends.PTX;
 using ILGPU.IR.Intrinsics;
 using System;
@@ -54,6 +55,19 @@ namespace ILGPU.Algorithms.PTX
         /// The <see cref="PTXWarpExtensions"/> type.
         /// </summary>
         internal static readonly Type PTXWarpExtensionsType = typeof(PTXWarpExtensions);
+
+        /// <summary>
+        /// Resolves a PTX code generator for the given math-function configuration.
+        /// </summary>
+        /// <param name="minArchitecture">The target/minimum architecture.</param>
+        /// <returns>The resolved intrinsic representation.</returns>
+        private static PTXIntrinsic GetMathCodeGeneratorIntrinsic(
+            PTXArchitecture minArchitecture) =>
+            new PTXIntrinsic(
+                PTXMathType,
+                nameof(PTXMath.GenerateMathIntrinsic),
+                IntrinsicImplementationMode.GenerateCode,
+                minArchitecture);
 
         /// <summary>
         /// Resolves a PTX intrinsic for the given math-function configuration.


### PR DESCRIPTION
Fixed https://github.com/m4rs-mt/ILGPU.Algorithms/issues/46.

Register the software fallback first, so that it gets replaced by the specialized hardware intrinsic.