### PR TITLE
Added new RadixSortPairs functions

### DIFF
--- a/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
@@ -24,9 +24,9 @@ namespace ILGPU.Algorithms.Tests
 
         #region MemberData
 
-        public static TheoryData< object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object, object, object>
             AscendingTestData =>
-            new TheoryData< object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, object>
         {
             // Type, RadixSortOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
@@ -43,9 +43,26 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData< object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object>
+            AscendingPairsTestData =>
+            new TheoryData<object, object, object, object>
+        {
+            // Type, RadixSortOperation, Sequencer, Start of Sequencer, BufferLength
+<#
+        foreach (var type in types) {
+            foreach (var size in ArraySizes.Skip(7)) {
+#>
+            { default(<#= type.Type #>), default(XunitAscending<#= type.Name #>),
+                default(<#= type.Name #>TestSequencer), <#= size #> },
+<#
+            }
+        }
+#>
+        };
+
+        public static TheoryData<object, object, object, object, object, object>
             DescendingTestData =>
-            new TheoryData< object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, object>
         {
             // Type, RadixSortOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
@@ -61,9 +78,26 @@ namespace ILGPU.Algorithms.Tests
 #>
         };
 
-        public static TheoryData< object, object, object, object, object, object>
+        public static TheoryData<object, object, object, object>
+            DescendingPairsTestData =>
+            new TheoryData<object, object, object, object>
+        {
+            // Type, RadixSortOperation, Sequencer, BufferLength
+<#
+        foreach (var type in types) {
+            foreach (var size in ArraySizes.Skip(7)) {
+#>
+            { default(<#= type.Type #>), default(XunitDescending<#= type.Name #>),
+                default(<#= type.Name #>TestSequencer), <#= size #> },
+<#
+            }
+        }
+#>
+        };
+
+        public static TheoryData<object, object, object, object, object, object>
             ConstantTestData =>
-            new TheoryData< object, object, object, object, object, object>
+            new TheoryData<object, object, object, object, object, object>
         {
             // Type, RadixSortOperation, Sequencer, Start of Sequencer,
             // StepSize of Sequencer, BufferLength
@@ -284,6 +318,60 @@ namespace ILGPU.Algorithms.Tests
             stream.Synchronize();
 
             Verify(input, sequence);
+        }
+
+        [Theory]
+        [MemberData(nameof(<#= sorting.Name #>TestData))]
+        public void RadixSortPairs<#= sorting.Name #><T, TRadixSortOp, TSequencer>(
+            T _,
+            TRadixSortOp radixSortOp,
+            TSequencer sequencer,
+            T start,
+            T stepSize,
+            int length)
+            where T : unmanaged
+            where TRadixSortOp : struct, IRadixSortOperation<T>
+            where TSequencer : struct, ITestSequencer<T>
+        {
+            using var keys = Accelerator.Allocate<T>(length);
+            using var values = Accelerator.Allocate<T>(length);
+            using var stream = Accelerator.CreateStream();
+
+            var sourceSequence = sequencer.ComputeSequence(start, stepSize, length);
+            var targetSequence = sequencer.ComputeInvertedSequence(
+                start,
+                stepSize,
+                length);
+
+<#      if (!sorting.IsDescendingSorting) { #>
+            Util.Utilities.Swap(ref sourceSequence, ref targetSequence);
+<#      } #>
+
+            keys.CopyFrom(
+                stream,
+                sourceSequence,
+                0,
+                0,
+                length);
+            values.CopyFrom(
+                stream,
+                sourceSequence,
+                0,
+                0,
+                length);
+            stream.Synchronize();
+
+            var radixSort = Accelerator.CreateRadixSortPairs<T, T, TRadixSortOp>();
+            var tempMemSize =
+                Accelerator.ComputeRadixSortPairsTempStorageSize<T, T, TRadixSortOp>(
+                    length);
+            using var tmpBuffer = Accelerator.Allocate<int>(tempMemSize);
+
+            radixSort(stream, keys.View, values.View, tmpBuffer.View);
+            stream.Synchronize();
+
+            Verify(keys, targetSequence);
+            Verify(values, targetSequence);
         }
 
 <#

--- a/Src/ILGPU.Algorithms/Sequencer.cs
+++ b/Src/ILGPU.Algorithms/Sequencer.cs
@@ -36,7 +36,8 @@ namespace ILGPU.Algorithms.Sequencers
     public readonly struct IndexSequencer : ISequencer<Index1>
     {
         /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public Index1 ComputeSequenceElement(Index1 sequenceIndex) => sequenceIndex;
+        public readonly Index1 ComputeSequenceElement(Index1 sequenceIndex) =>
+            sequenceIndex;
     }
 
     /// <summary>
@@ -45,7 +46,7 @@ namespace ILGPU.Algorithms.Sequencers
     public readonly struct HalfSequencer : ISequencer<Half>
     {
         /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public Half ComputeSequenceElement(Index1 sequenceIndex) =>
+        public readonly Half ComputeSequenceElement(Index1 sequenceIndex) =>
             (Half)sequenceIndex.X;
     }
 
@@ -55,7 +56,8 @@ namespace ILGPU.Algorithms.Sequencers
     public readonly struct FloatSequencer : ISequencer<float>
     {
         /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public float ComputeSequenceElement(Index1 sequenceIndex) => sequenceIndex;
+        public readonly float ComputeSequenceElement(Index1 sequenceIndex) =>
+            sequenceIndex;
     }
 
     /// <summary>
@@ -64,6 +66,35 @@ namespace ILGPU.Algorithms.Sequencers
     public readonly struct DoubleSequencer : ISequencer<double>
     {
         /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public double ComputeSequenceElement(Index1 sequenceIndex) => sequenceIndex;
+        public readonly double ComputeSequenceElement(Index1 sequenceIndex) =>
+            sequenceIndex;
+    }
+
+    /// <summary>
+    /// Represents a sequencer that wraps an array view in a sequencer.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    public readonly struct ViewSourceSequencer<T> : ISequencer<T>
+        where T : unmanaged
+    {
+        /// <summary>
+        /// Constructs a new sequencer.
+        /// </summary>
+        /// <param name="viewSource">The underlying view source.</param>
+        public ViewSourceSequencer(ArrayView<T> viewSource)
+        {
+            ViewSource = viewSource;
+        }
+
+        /// <summary>
+        /// Returns the data source of this sequence.
+        /// </summary>
+        public ArrayView<T> ViewSource { get; }
+
+        /// <summary>
+        /// Returns the i-th element of the attached <see cref="ViewSource"/>.
+        /// </summary>
+        public readonly T ComputeSequenceElement(Index1 sequenceIndex) =>
+            ViewSource[sequenceIndex];
     }
 }


### PR DESCRIPTION
This PR adds a `RadixSortPairs` wrapper + additional utilities to implement specialized versions of it. It meets the requirements of the community to sort key-value pairs. Furthermore, it includes test cases to verify the functionality of the newly added sort-pairs extension methods.