### PR TITLE
Added support for unit tests running on net47.

### DIFF
--- a/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
+++ b/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\..\ILGPU\Src\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\..\ILGPU\Src\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
@@ -1,10 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\..\ILGPU\Src\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestBase.cs
+++ b/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestBase.cs
@@ -33,7 +33,11 @@ namespace ILGPU.Algorithms.Tests
             public readonly float Margin;
 
             public HalfPrecisionComparer(uint decimalPlaces) =>
+#if NETFRAMEWORK
+                Margin = (float)Math.Pow(10, -decimalPlaces);
+#else
                 Margin = MathF.Pow(10, -decimalPlaces);
+#endif
 
             public override bool Equals(Half x, Half y)
             {
@@ -65,7 +69,11 @@ namespace ILGPU.Algorithms.Tests
             public readonly float Margin;
 
             public FloatPrecisionComparer(uint decimalPlaces) =>
+#if NETFRAMEWORK
+                Margin = (float)Math.Pow(10, -decimalPlaces);
+#else
                 Margin = MathF.Pow(10, -decimalPlaces);
+#endif
 
             public override bool Equals(float x, float y)
             {

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
@@ -9,6 +10,10 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\..\ILGPU\Src\ILGPU.Tests\.test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.BitOperations.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.BitOperations.tt
@@ -74,6 +74,88 @@ namespace ILGPU.Algorithms.Tests
 
 <# } #>
     }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Naive implementation of BitOperations for .NET Framework.
+    /// </summary>
+    static class BitOperations
+    {
+        public static int LeadingZeroCount(uint value)
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                var bitmask = 1 << 32 - i - 1;
+                if ((value & bitmask) != 0)
+                    return i;
+            }
+
+            return 32;
+        }
+
+        public static int LeadingZeroCount(ulong value)
+        {
+            for (int i = 0; i < 64; i++)
+            {
+                var bitmask = 1UL << 64 - i - 1;
+                if ((value & bitmask) != 0)
+                    return i;
+            }
+
+            return 64;
+        }
+
+        public static int TrailingZeroCount(uint value)
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                var bitmask = 1 << i;
+                if ((value & bitmask) != 0)
+                    return i;
+            }
+
+            return 32;
+        }
+        
+        public static int TrailingZeroCount(ulong value)
+        {
+            for (int i = 0; i < 64; i++)
+            {
+                var bitmask = 1UL << i;
+                if ((value & bitmask) != 0)
+                    return i;
+            }
+
+            return 64;
+        }
+
+        public static int PopCount(uint value)
+        {
+            int count = 0;
+            for (int i = 0; i < 32; i++)
+            {
+                var bitmask = 1 << i;
+                if ((value & bitmask) != 0)
+                    count++;
+            }
+
+            return count;
+        }
+
+        public static int PopCount(ulong value)
+        {
+            int count = 0;
+            for (int i = 0; i < 64; i++)
+            {
+                var bitmask = 1UL << i;
+                if ((value & bitmask) != 0)
+                    count++;
+            }
+
+            return count;
+        }
+    }
+#endif
 }
 
 #pragma warning restore xUnit1025 // InlineData should be unique within the Theory it

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
@@ -94,7 +94,12 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
-                x => Math<#= function.MathSuffix #>.<#= function.Name #>(x)).ToArray();
+#if NETFRAMEWORK
+                x => (<#= function.DataType #>)Math.<#= function.Name #>(x))
+#else
+                x => Math<#= function.MathSuffix #>.<#= function.Name #>(x))
+#endif
+                .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
@@ -150,7 +155,12 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
-                x => Math<#= function.MathSuffix #>.Log(x, 2)).ToArray();
+#if NETFRAMEWORK
+                x => (<#= function.DataType #>)Math.Log(x, 2))
+#else
+                x => Math<#= function.MathSuffix #>.Log(x, 2))
+#endif
+                .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
@@ -221,7 +231,13 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
-                v => Math<#= function.MathSuffix #>.Log(v.X, v.Y)).ToArray();
+#if NETFRAMEWORK
+                v => (<#= function.DataType #>)Math.Log(v.X, v.Y))
+#else
+                v => Math<#= function.MathSuffix #>.Log(v.X, v.Y))
+#endif
+                .ToArray();
+
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
@@ -115,7 +115,11 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
+#if NETFRAMEWORK
+                v => (<#= function.DataType #>)Math.<#= function.Name #>(v.X, v.Y))
+#else
                 v => Math<#= function.MathSuffix #>.<#= function.Name #>(v.X, v.Y))
+#endif
                 .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
@@ -180,7 +184,11 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
+#if NETFRAMEWORK
+                x => (<#= function.DataType #>)Math.Pow(
+#else
                 x => Math<#= function.MathSuffix #>.Pow(
+#endif
                     2.0<#= function.ValueSuffix #>, x)).ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
@@ -245,7 +253,12 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
-                x => Math<#= function.MathSuffix #>.<#= function.Name #>(x)).ToArray();
+#if NETFRAMEWORK
+                x => (<#= function.DataType #>)Math.<#= function.Name #>(x))
+#else
+                x => Math<#= function.MathSuffix #>.<#= function.Name #>(x))
+#endif
+                .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
                     output,

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rem.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rem.tt
@@ -27,23 +27,23 @@ using Xunit;
         new RemFunction(
             "Rem",
             "float",
-            "{0} % {1}",
+            "{1} % {2}",
             new RelativeError(0E-00, 1E-06, 0E-00)),
         new RemFunction(
             "Rem",
             "double",
-            "{0} % {1}",
+            "{1} % {2}",
             new RelativeError(0E-00, 1E-06, 0E-00)),
 
         new RemFunction(
             "IEEERemainder",
             "float",
-            "MathF.IEEERemainder({0}, {1})",
+            "{0}.IEEERemainder({1}, {2})",
             new RelativeError(0E-00, 1E-06, 0E-00)),
         new RemFunction(
             "IEEERemainder",
             "double",
-            "Math.IEEERemainder({0}, {1})",
+            "{0}.IEEERemainder({1}, {2})",
             new RelativeError(0E-00, 1E-06, 0E-00)),
     };
 #>
@@ -96,7 +96,21 @@ namespace ILGPU.Algorithms.Tests
                 .ToArray();
             var expected = inputArray
                 .Select(x =>
-                    <#= string.Format(function.ExpectedFormatString, "x", "divisor") #>)
+#if NETFRAMEWORK
+                    <#= string.Format(
+                            function.ExpectedFormatString,
+                            "(" + function.DataType + ")Math",
+                            "x",
+                            "divisor")
+                    #>)
+#else
+                    <#= string.Format(
+                            function.ExpectedFormatString,
+                            "Math" + function.MathSuffix,
+                            "x",
+                            "divisor")
+                    #>)
+#endif
                 .ToArray();
             using var input =
                 Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Round.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Round.tt
@@ -25,29 +25,29 @@ using Xunit;
         new RoundFunction(
             "RoundAwayFromZero",
             "float",
-            "MathF.Round({0}, MidpointRounding.AwayFromZero)"),
+            "{0}.Round({1}, MidpointRounding.AwayFromZero)"),
         new RoundFunction(
             "RoundAwayFromZero",
             "double",
-            "Math.Round({0}, MidpointRounding.AwayFromZero)"),
+            "{0}.Round({1}, MidpointRounding.AwayFromZero)"),
 
         new RoundFunction(
             "RoundToEven",
             "float",
-            "MathF.Round({0}, MidpointRounding.ToEven)"),
+            "{0}.Round({1}, MidpointRounding.ToEven)"),
         new RoundFunction(
             "RoundToEven",
             "double",
-            "Math.Round({0}, MidpointRounding.ToEven)"),
+            "{0}.Round({1}, MidpointRounding.ToEven)"),
 
-        new RoundFunction("Truncate",   "float" ,   "MathF.Truncate({0})"),
-        new RoundFunction("Truncate",   "double",   "Math.Truncate({0})"),
+        new RoundFunction("Truncate",   "float" ,   "{0}.Truncate({1})"),
+        new RoundFunction("Truncate",   "double",   "{0}.Truncate({1})"),
 
-        new RoundFunction("Floor",      "float" ,   "MathF.Floor({0})"),
-        new RoundFunction("Floor",      "double",   "Math.Floor({0})"),
+        new RoundFunction("Floor",      "float" ,   "{0}.Floor({1})"),
+        new RoundFunction("Floor",      "double",   "{0}.Floor({1})"),
 
-        new RoundFunction("Ceiling",    "float" ,   "MathF.Ceiling({0})"),
-        new RoundFunction("Ceiling",    "double",   "Math.Ceiling({0})"),
+        new RoundFunction("Ceiling",    "float" ,   "{0}.Ceiling({1})"),
+        new RoundFunction("Ceiling",    "double",   "{0}.Ceiling({1})"),
     };
 #>
 namespace ILGPU.Algorithms.Tests
@@ -68,7 +68,11 @@ namespace ILGPU.Algorithms.Tests
                 2.8<#= function.ValueSuffix #>,
                 2.5<#= function.ValueSuffix #>,
                 3.5<#= function.ValueSuffix #>,
+#if NETFRAMEWORK
+                (<#= function.DataType #>)Math.Pow(2, 53),
+#else
                 Math<#= function.MathSuffix #>.Pow(2, 53),
+#endif
                 -0.0<#= function.ValueSuffix #>,
                 -0.4<#= function.ValueSuffix #>,
                 -0.5<#= function.ValueSuffix #>,
@@ -78,7 +82,11 @@ namespace ILGPU.Algorithms.Tests
                 -2.5<#= function.ValueSuffix #>,
                 -2.8<#= function.ValueSuffix #>,
                 -3.5<#= function.ValueSuffix #>,
+#if NETFRAMEWORK
+                (<#= function.DataType #>)-Math.Pow(2, 53),
+#else
                 -Math<#= function.MathSuffix #>.Pow(2, 53),
+#endif
                 <#= function.DataType #>.NaN,
                 <#= function.DataType #>.PositiveInfinity,
                 <#= function.DataType #>.NegativeInfinity,
@@ -99,7 +107,19 @@ namespace ILGPU.Algorithms.Tests
         {
             var expected = new[]
             {
-                <#= string.Format(function.ExpectedFormatString, "value") #>
+#if NETFRAMEWORK
+                <#= string.Format(
+                        function.ExpectedFormatString,
+                        "(" + function.DataType + ")Math",
+                        "value")
+                #>
+#else
+                <#= string.Format(
+                        function.ExpectedFormatString,
+                        "Math" + function.MathSuffix,
+                        "value")
+                #>
+#endif
             };
             using var input = Accelerator.Allocate<<#= function.DataType #>>(1);
             using var output = Accelerator.Allocate<<#= function.DataType #>>(1);

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Sqrt.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Sqrt.tt
@@ -85,7 +85,12 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
-                Math<#= function.MathSuffix #>.<#= function.Name #>).ToArray();
+#if NETFRAMEWORK
+                x => (<#= function.DataType #>)Math.<#= function.Name #>(x))
+#else
+                Math<#= function.MathSuffix #>.<#= function.Name #>)
+#endif
+                .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
@@ -141,7 +146,12 @@ namespace ILGPU.Algorithms.Tests
 
             var expected = inputArray.Select(
                 x => 1.0<#= function.ValueSuffix #> /
-                    Math<#= function.MathSuffix #>.Sqrt(x)).ToArray();
+#if NETFRAMEWORK
+                    (<#= function.DataType #>)Math.Sqrt(x))
+#else
+                    Math<#= function.MathSuffix #>.Sqrt(x))
+#endif
+                    .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
@@ -33,12 +33,12 @@ using Xunit;
         new TrigFunction("Tan", "float"  , new Precision(15,  3,  5), projection: ".Select(x => XMath.DegToRad((float)x))" , condition: ".Where(x => Math.Abs(x) % 360 != 90 && Math.Abs(x) % 360 != 270) // NB: Tan is undefined for these input values"),
         new TrigFunction("Tan", "double" , new Precision(15, 12, 14), projection: ".Select(x => XMath.DegToRad((double)x))", condition: ".Where(x => Math.Abs(x) % 360 != 90 && Math.Abs(x) % 360 != 270) // NB: Tan is undefined for these input values"),
 
-        new TrigFunction("Asin", "float" , new Precision(15,  6,  6), projection: ".Select(x => MathF.Sin(XMath.DegToRad((float)x)))"),
-        new TrigFunction("Asin", "double", new Precision(15, 15, 15), projection: ".Select(x => Math.Sin(XMath.DegToRad((double)x)))"),
-        new TrigFunction("Acos", "float" , new Precision(15,  6,  6), projection: ".Select(x => MathF.Cos(XMath.DegToRad((float)x)))"),
-        new TrigFunction("Acos", "double", new Precision(15, 15, 15), projection: ".Select(x => Math.Cos(XMath.DegToRad((double)x)))"),
-        new TrigFunction("Atan", "float" , new Precision(15,  6,  6), projection: ".Select(x => MathF.Tan(XMath.DegToRad((float)x)))"),
-        new TrigFunction("Atan", "double", new Precision(15, 15, 15), projection: ".Select(x => Math.Tan(XMath.DegToRad((double)x)))"),
+        new TrigFunction("Asin", "float" , new Precision(15,  6,  6), projection: ".Select(x => {0}.Sin(XMath.DegToRad((float)x)))"),
+        new TrigFunction("Asin", "double", new Precision(15, 15, 15), projection: ".Select(x => {0}.Sin(XMath.DegToRad((double)x)))"),
+        new TrigFunction("Acos", "float" , new Precision(15,  6,  6), projection: ".Select(x => {0}.Cos(XMath.DegToRad((float)x)))"),
+        new TrigFunction("Acos", "double", new Precision(15, 15, 15), projection: ".Select(x => {0}.Cos(XMath.DegToRad((double)x)))"),
+        new TrigFunction("Atan", "float" , new Precision(15,  6,  6), projection: ".Select(x => {0}.Tan(XMath.DegToRad((float)x)))"),
+        new TrigFunction("Atan", "double", new Precision(15, 15, 15), projection: ".Select(x => {0}.Tan(XMath.DegToRad((double)x)))"),
 
         new TrigFunction("Sinh", "float" , new Precision(15,  4,  4), projection: ".Select(x => XMath.DegToRad((float)x))"),
         new TrigFunction("Sinh", "double", new Precision(15, 12, 13), projection: ".Select(x => XMath.DegToRad((double)x))"),
@@ -82,7 +82,11 @@ namespace ILGPU.Algorithms.Tests
                 Enumerable.Range(
                     <#= startRange #>,
                     <#= endRange - startRange + 1 #>)<#= function.Condition #>
-                <#= function.Projection #>
+#if NETFRAMEWORK
+                <#= string.Format(function.Projection, "(" + function.DataType + ")Math") #>
+#else
+                <#= string.Format(function.Projection, "Math" + function.MathSuffix) #>
+#endif
                 .Concat(new <#= function.DataType #>[]
                 {
                     0.0<#= function.ValueSuffix #>,
@@ -99,7 +103,12 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
-                Math<#= function.MathSuffix #>.<#= function.Name #>).ToArray();
+#if NETFRAMEWORK
+                x => (<#= function.DataType #>)Math.<#= function.Name #>(x))
+#else
+                Math<#= function.MathSuffix #>.<#= function.Name #>)
+#endif
+                .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
@@ -168,8 +177,12 @@ namespace ILGPU.Algorithms.Tests
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
-                v => Math<#= function.MathSuffix #>.<#= function.Name #>(
-                    v.X, v.Y)).ToArray();
+#if NETFRAMEWORK
+                v => (<#= function.DataType #>)Math.<#= function.Name #>(v.X, v.Y))
+#else
+                v => Math<#= function.MathSuffix #>.<#= function.Name #>(v.X, v.Y))
+#endif
+                    .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)


### PR DESCRIPTION
Depends on #69.

As per https://github.com/m4rs-mt/ILGPU/pull/355, enforce running tests on native platform architecture.
Deal with missing `MathF` in `net47` by using preprocessor.
Deal with missing `BitOperations` in `net47` by including a naive implementation.