### PR TITLE
Support for latest ILGPU version in master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,12 @@ jobs:
           dotnet-version: 3.1.407
       - name: Pin .NET Core SDK
         run: dotnet new globaljson --sdk-version 3.1.407
-      - name: Restore tools
-        run: dotnet tool restore
-        working-directory: ./Src
-      - name: Build templates
-        # TargetFramework specified so this only runs once rather than per framework
-        run: dotnet msbuild -t:TextTemplateTransform -p:TargetFramework=NA Src
+        # WORKAROUND: Reset NuGet sources to default to avoid restore issues
+        # on Windows runners where the Visual Studio offline source seems to
+        # cause random issues.
+      - name: Reset NuGet sources
+        if: runner.os == 'Windows'
+        run: dotnet new nugetconfig
       - name: Release Build
         run: dotnet build --configuration=Release -p:TreatWarningsAsErrors=true Src
       - name: CPU Tests

--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ ILGPU.Algorithms requires Visual Studio 2019 or higher.
 
 Make sure to init/update the ILGPU git submodule using `git submodule update --init` before building the algorithms library.
 
-Note: T4 (*.tt) text templates must be converted manually depending on the Visual Studio version.
-To transform them, right-click a text template and select Run Custom Tool. Alternatively, you can open and save any text template in Visual Studio or choose
-"Build->Transform all T4 Templates".
-
 # License information
 
 ILGPU.Algorithms is licensed under the University of Illinois/NCSA Open Source License.

--- a/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
@@ -20,7 +20,7 @@ namespace ILGPU.Algorithms.Tests.CPU
         public CPUTestContext<#= optLevel #>()
             : base(
                 OptimizationLevel.<#= optLevel #>,
-                context => context.EnableAlgorithms())
+                builder => builder.EnableAlgorithms())
         { }
     }
 

--- a/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.CPU/Configurations.tt
@@ -2,7 +2,6 @@
 <#@ include file="../../ILGPU/Src/ILGPU.Tests/Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.IR.Transformations;
 using ILGPU.Tests.CPU;
 using Xunit;

--- a/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
+++ b/Src/ILGPU.Algorithms.Tests.CPU/ILGPU.Algorithms.Tests.CPU.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
-
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' AND '$(GITHUB_ACTIONS)' == 'true'">
+    <TargetFrameworks>$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Channel)' == 'experimental'">
@@ -33,6 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
@@ -68,6 +71,4 @@
       <DependentUpon>Configurations.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <Import Project="..\..\ILGPU\Src\TextTransform.targets" />
 </Project>

--- a/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
@@ -20,7 +20,7 @@ namespace ILGPU.Algorithms.Tests.Cuda
         public CudaTestContext<#= optLevel #>()
             : base(
                 OptimizationLevel.<#= optLevel #>,
-                context => context.EnableAlgorithms())
+                builder => builder.EnableAlgorithms())
         { }
     }
 

--- a/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/Configurations.tt
@@ -2,7 +2,6 @@
 <#@ include file="../../ILGPU/Src/ILGPU.Tests/Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.IR.Transformations;
 using ILGPU.Tests.Cuda;
 using Xunit;

--- a/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
+++ b/Src/ILGPU.Algorithms.Tests.Cuda/ILGPU.Algorithms.Tests.Cuda.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
-
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' AND '$(GITHUB_ACTIONS)' == 'true'">
+    <TargetFrameworks>$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Channel)' == 'experimental'">
@@ -33,6 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
@@ -68,6 +71,4 @@
       <DependentUpon>Configurations.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <Import Project="..\..\ILGPU\Src\TextTransform.targets" />
 </Project>

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
@@ -20,7 +20,7 @@ namespace ILGPU.Algorithms.Tests.OpenCL
         public CLTestContext<#= optLevel #>()
             : base(
                 OptimizationLevel.<#= optLevel #>,
-                context => context.EnableAlgorithms())
+                builder => builder.EnableAlgorithms())
         { }
     }
 

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/Configurations.tt
@@ -2,7 +2,6 @@
 <#@ include file="../../ILGPU/Src/ILGPU.Tests/Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.IR.Transformations;
 using ILGPU.Tests.OpenCL;
 using Xunit;

--- a/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
+++ b/Src/ILGPU.Algorithms.Tests.OpenCL/ILGPU.Algorithms.Tests.OpenCL.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
-
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' AND '$(GITHUB_ACTIONS)' == 'true'">
+    <TargetFrameworks>$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Channel)' == 'experimental'">
@@ -33,6 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
@@ -68,6 +71,4 @@
       <DependentUpon>Configurations.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <Import Project="..\..\ILGPU\Src\TextTransform.targets" />
 </Project>

--- a/Src/ILGPU.Algorithms.Tests/ArrayExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ArrayExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Tests;
 using Xunit;
@@ -76,7 +75,7 @@ namespace ILGPU.Algorithms.Tests
             where T : unmanaged
         {
             T[] dummy = new T[lenX];
-            Index1 actual = ArrayExtensions.GetExtent(dummy);
+            Index1D actual = ArrayExtensions.GetExtent(dummy);
             Assert.Equal(lenX, actual.X);
         }
 
@@ -86,7 +85,7 @@ namespace ILGPU.Algorithms.Tests
             where T : unmanaged
         {
             T[,] dummy = new T[lenX, lenY];
-            Index2 actual = ArrayExtensions.GetExtent(dummy);
+            Index2D actual = ArrayExtensions.GetExtent(dummy);
             Assert.Equal(lenX, actual.X);
             Assert.Equal(lenY, actual.Y);
         }
@@ -97,7 +96,7 @@ namespace ILGPU.Algorithms.Tests
             where T : unmanaged
         {
             T[,,] dummy = new T[lenX, lenY, lenZ];
-            Index3 actual = ArrayExtensions.GetExtent(dummy);
+            Index3D actual = ArrayExtensions.GetExtent(dummy);
             Assert.Equal(lenX, actual.X);
             Assert.Equal(lenY, actual.Y);
             Assert.Equal(lenZ, actual.Z);
@@ -109,7 +108,7 @@ namespace ILGPU.Algorithms.Tests
             where T : unmanaged
         {
             T[] dummy = new T[lenX];
-            Index1 index = lenX/2;
+            Index1D index = lenX/2;
             ArrayExtensions.SetValue(dummy, value, index);
             var actual = ArrayExtensions.GetValue(dummy, index);
             Assert.Equal(value, actual);
@@ -121,7 +120,7 @@ namespace ILGPU.Algorithms.Tests
             where T : unmanaged
         {
             T[,] dummy = new T[lenX, lenY];
-            Index2 index = new Index2(lenX/2, lenY/3);
+            Index2D index = new Index2D(lenX/2, lenY/3);
             ArrayExtensions.SetValue(dummy, value, index);
             var actual = ArrayExtensions.GetValue(dummy, index);
             Assert.Equal(value, actual);
@@ -133,7 +132,7 @@ namespace ILGPU.Algorithms.Tests
             where T : unmanaged
         {
             T[,,] dummy = new T[lenX, lenY, lenZ];
-            Index3 index = new Index3(lenX/2, lenY/3, lenZ/4);
+            Index3D index = new Index3D(lenX/2, lenY/3, lenZ/4);
             ArrayExtensions.SetValue(dummy, value, index);
             var actual = ArrayExtensions.GetValue(dummy, index);
             Assert.Equal(value, actual);

--- a/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestBase.cs
+++ b/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestBase.cs
@@ -255,7 +255,7 @@ namespace ILGPU.Algorithms.Tests
         /// <param name="expected">The expected values.</param>
         /// <param name="decimalPlaces">The acceptable error margin.</param>
         public void VerifyWithinPrecision(
-            MemoryBuffer<Half> buffer,
+            ArrayView<Half> buffer,
             Half[] expected,
             uint decimalPlaces)
         {
@@ -274,7 +274,7 @@ namespace ILGPU.Algorithms.Tests
         /// <param name="expected">The expected values.</param>
         /// <param name="decimalPlaces">The acceptable error margin.</param>
         public void VerifyWithinPrecision(
-            MemoryBuffer<float> buffer,
+            ArrayView<float> buffer,
             float[] expected,
             uint decimalPlaces)
         {
@@ -293,7 +293,7 @@ namespace ILGPU.Algorithms.Tests
         /// <param name="expected">The expected values.</param>
         /// <param name="decimalPlaces">The acceptable error margin.</param>
         public void VerifyWithinPrecision(
-            MemoryBuffer<double> buffer,
+            ArrayView<double> buffer,
             double[] expected,
             uint decimalPlaces)
         {
@@ -312,7 +312,7 @@ namespace ILGPU.Algorithms.Tests
         /// <param name="expected">The expected values.</param>
         /// <param name="relativeError">The acceptable error margin.</param>
         public void VerifyWithinRelativeError(
-            MemoryBuffer<Half> buffer,
+            ArrayView<Half> buffer,
             Half[] expected,
             double relativeError)
         {
@@ -331,7 +331,7 @@ namespace ILGPU.Algorithms.Tests
         /// <param name="expected">The expected values.</param>
         /// <param name="relativeError">The acceptable error margin.</param>
         public void VerifyWithinRelativeError(
-            MemoryBuffer<float> buffer,
+            ArrayView<float> buffer,
             float[] expected,
             double relativeError)
         {
@@ -350,7 +350,7 @@ namespace ILGPU.Algorithms.Tests
         /// <param name="expected">The expected values.</param>
         /// <param name="relativeError">The acceptable error margin.</param>
         public void VerifyWithinRelativeError(
-            MemoryBuffer<double> buffer,
+            ArrayView<double> buffer,
             double[] expected,
             double relativeError)
         {

--- a/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestData.tt
+++ b/Src/ILGPU.Algorithms.Tests/Generic/AlgorithmsTestData.tt
@@ -2,7 +2,6 @@
 <#@ include file="ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Algorithms.RadixSortOperations;
 using ILGPU.Algorithms.ScanReduceOperations;
@@ -89,23 +88,23 @@ namespace ILGPU.Algorithms.Tests
 <#
     }
 #>
-    internal readonly struct Index1TestSequencer : ITestSequencer<Index1>
+    internal readonly struct Index1TestSequencer : ITestSequencer<Index1D>
     {
-        public Index1[] ComputeSequence(Index1 start, Index1 stepSize, int length)
+        public Index1D[] ComputeSequence(Index1D start, Index1D stepSize, int length)
         {
-            Index1[] sequence = new Index1[length];
+            Index1D[] sequence = new Index1D[length];
             sequence[0] = start;
             for (int i = 1; i < length; ++i)
                 sequence[i] = sequence[i-1] + stepSize;
             return sequence;
         }
 
-        public Index1[] ComputeInvertedSequence(
-            Index1 start,
-            Index1 stepSize,
+        public Index1D[] ComputeInvertedSequence(
+            Index1D start,
+            Index1D stepSize,
             int length)
         {
-            Index1[] sequence = new Index1[length];
+            Index1D[] sequence = new Index1D[length];
             sequence[length-1] = start;
             for (int i = length-2; i >= 0; --i)
                 sequence[i] = sequence[i+1] + stepSize;
@@ -255,16 +254,16 @@ namespace ILGPU.Algorithms.Tests
     foreach (var type in types) {
 #>
     internal readonly struct Index1To<#= type.Name #>Transformer 
-        : ITransformer<Index1, <#= type.Type #>>, IXunitSerializable
+        : ITransformer<Index1D, <#= type.Type #>>, IXunitSerializable
     {
 <#
         if(type.IsUnsignedInt) {
 #>
-        public <#= type.Type #> Transform(Index1 value) => (<#= type.Type #>)value;
+        public <#= type.Type #> Transform(Index1D value) => (<#= type.Type #>)value;
 <#
         }else{
 #>
-        public <#= type.Type #> Transform(Index1 value) => value;
+        public <#= type.Type #> Transform(Index1D value) => value;
 <#
         }
 #>

--- a/Src/ILGPU.Algorithms.Tests/Generic/ConfigurationBase.tt
+++ b/Src/ILGPU.Algorithms.Tests/Generic/ConfigurationBase.tt
@@ -2,6 +2,7 @@
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
 <#@ include file="../../ILGPU.Algorithms/TypeInformation.ttinclude" #>
 <#+
 public enum SequenceSortingKind

--- a/Src/ILGPU.Algorithms.Tests/GroupExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/GroupExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Algorithms.ScanReduceOperations;
 using ILGPU.Runtime;
@@ -32,8 +31,8 @@ namespace ILGPU.Algorithms.Tests
         foreach (var func in WarpFunctions) {
 #>
         internal static void <#= func #>Kernel<T, TFunction>(
-            ArrayView<T> input,
-            ArrayView<T> output)
+            ArrayView1D<T, Stride1D.Dense> input,
+            ArrayView1D<T, Stride1D.Dense> output)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {
@@ -103,22 +102,18 @@ namespace ILGPU.Algorithms.Tests
             where TSequencer : struct, ITestSequencer<T>
         {
             var size = Math.Max(Accelerator.MaxNumThreadsPerGroup / fraction, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
 
-            input.CopyFrom(
+            input.CopyFromCPU(
                 stream,
-                sequencer.ComputeSequence(start, stepSize, size),
-                0,
-                0,
-                size);
-            stream.Synchronize();
+                sequencer.ComputeSequence(start, stepSize, size));
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
-            T expected = CalcValue(input, func);
-            T actual = output.GetAsArray()[0];
+            T expected = CalcValue<T, TFunction>(input.View, func);
+            T actual = output.View.GetAs1DArray()[0];
             Assert.Equal(expected, actual);
         }
 
@@ -139,22 +134,20 @@ namespace ILGPU.Algorithms.Tests
             where TSequencer : struct, ITestSequencer<T>
         {
             var size = Math.Max(Accelerator.MaxNumThreadsPerGroup / fraction, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
 
-            input.CopyFrom(
+            input.CopyFromCPU(
                 stream,
-                sequencer.ComputeSequence(start, stepSize, size),
-                0,
-                0,
-                size);
-            stream.Synchronize();
+                sequencer.ComputeSequence(start, stepSize, size));
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
             
-            var expected = Enumerable.Repeat(CalcValue(input, func), size).ToArray();
-            Verify(output, expected);
+            var expected = Enumerable.Repeat(
+                CalcValue<T, TFunction>(input.View, func),
+                size).ToArray();
+            Verify(output.View, expected);
         }
 
         [Theory]
@@ -172,22 +165,21 @@ namespace ILGPU.Algorithms.Tests
             where TSequencer : struct, ITestSequencer<T>
         {
             var size = Math.Max(Accelerator.MaxNumThreadsPerGroup / fraction, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
 
-            input.CopyFrom(
+            input.CopyFromCPU(
                 stream,
-                sequencer.ComputeSequence(start, stepSize, size),
-                0,
-                0,
-                size);
-            stream.Synchronize();
+                sequencer.ComputeSequence(start, stepSize, size));
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
-            T[] expected = CalcValues(input, func, ScanKind.Exclusive);
-            Verify(output, expected);
+            T[] expected = CalcValues<T, TFunction>(
+                input.View,
+                func,
+                ScanKind.Exclusive);
+            Verify(output.View, expected);
         }
 
         [Theory]
@@ -206,22 +198,21 @@ namespace ILGPU.Algorithms.Tests
             where TSequencer : struct, ITestSequencer<T>
         {
             var size = Math.Max(Accelerator.MaxNumThreadsPerGroup / fraction, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
 
-            input.CopyFrom(
+            input.CopyFromCPU(
                 stream,
-                sequencer.ComputeSequence(start, stepSize, size),
-                0,
-                0,
-                size);
-            stream.Synchronize();
+                sequencer.ComputeSequence(start, stepSize, size));
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
-            T[] expected = CalcValues(input, func, ScanKind.Exclusive);
-            Verify(output, expected, 1);
+            T[] expected = CalcValues<T, TFunction>(
+                input.View,
+                func,
+                ScanKind.Exclusive);
+            Verify(output.View, expected, 1);
         }
 
         [Theory]
@@ -241,33 +232,30 @@ namespace ILGPU.Algorithms.Tests
             where TSequencer : struct, ITestSequencer<T>
         {
             var size = Math.Max(Accelerator.MaxNumThreadsPerGroup / fraction, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
 
-            input.CopyFrom(
+            input.CopyFromCPU(
                 stream,
-                sequencer.ComputeSequence(start, stepSize, size),
-                0,
-                0,
-                size);
-            stream.Synchronize();
+                sequencer.ComputeSequence(start, stepSize, size));
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
             
-            T[] expected = CalcValues(input, func, ScanKind.Inclusive);
-            Verify(output, expected);
+            T[] expected = CalcValues<T, TFunction>(
+                input.View,
+                func,
+                ScanKind.Inclusive);
+            Verify(output.View, expected);
         }
         
         #region Helper Methods
 
-        private T CalcValue<T, TFunction>(MemoryBuffer<T> buffer, TFunction func)
+        private static T CalcValue<T, TFunction>(ArrayView<T> buffer, TFunction func)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {
-            using var stream = Accelerator.CreateStream();
-            var values = buffer.GetAsArray(stream);
-            stream.Synchronize();
+            var values = buffer.GetAsArray();
             
             T result = values[0];
             for (int i = 1, e = values.Length; i < e; ++i)
@@ -275,16 +263,14 @@ namespace ILGPU.Algorithms.Tests
             return result;
         }
 
-        private T[] CalcValues<T, TFunction>(
-            MemoryBuffer<T> buffer,
+        private static T[] CalcValues<T, TFunction>(
+            ArrayView<T> buffer,
             TFunction func,
             ScanKind kind)
             where T : unmanaged
             where TFunction : struct, IScanReduceOperation<T>
         {
-            using var stream = Accelerator.CreateStream();
-            var values = buffer.GetAsArray(stream);
-            stream.Synchronize();
+            var values = buffer.GetAsArray();
 
             T[] result = new T[values.Length];
             result[0] = values[0];

--- a/Src/ILGPU.Algorithms.Tests/HistogramTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/HistogramTests.tt
@@ -19,8 +19,6 @@
 using ILGPU.Algorithms.HistogramOperations;
 using ILGPU.Runtime;
 using ILGPU.Tests;
-using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -42,56 +40,15 @@ namespace ILGPU.Algorithms.Tests
         #region Initialize Helpers
 
 <# foreach (var inputType in inputTypes) { #>
-        private static <#= inputType.Type #>[] InitializeInput1D_<#= inputType.Name #>(int length)
-        {
-            return Enumerable.Range(1, length).Select(x => (<#= inputType.Type #>)x).ToArray();
-        }
-
-        [SuppressMessage(
-            "Performance",
-            "CA1814:Prefer jagged arrays over multidimensional")]
-        private static <#= inputType.Type #>[,] InitializeInput2D_<#= inputType.Name #>(int length)
-        {
-            var inputArray = new <#= inputType.Type #>[length, length];
-            var values = Enumerable.Range(1, length * length).GetEnumerator();
-
-            for (var i = 0; i < length; i++)
-            {
-                for (var j = 0; j < length; j++)
-                {
-                    values.MoveNext();
-                    inputArray[i, j] = (<#= inputType.Type #>)values.Current;
-                }
-            }
-
-            return inputArray;
-        }
-
-        [SuppressMessage(
-            "Performance",
-            "CA1814:Prefer jagged arrays over multidimensional")]
-        private static <#= inputType.Type #>[,,] InitializeInput3D_<#= inputType.Name #>(int length)
-        {
-            var inputArray = new <#= inputType.Type #>[length, length, length];
-            var values = Enumerable.Range(1, length * length * length).GetEnumerator();
-
-            for (var i = 0; i < length; i++)
-            {
-                for (var j = 0; j < length; j++)
-                {
-                    for (var k = 0; k < length; k++)
-                    {
-                        values.MoveNext();
-                        inputArray[i, j, k] = (<#= inputType.Type #>)values.Current;
-                    }
-                }
-            }
-
-            return inputArray;
-        }
+        private static <#= inputType.Type #>[]
+            InitializeInput_<#= inputType.Name #>(int length) =>
+            Enumerable
+                .Range(1, length)
+                .Select(x => (<#= inputType.Type #>)x)
+                .ToArray();
 
 <# } #>
-        private static void ApplyHistogram1D<
+        private static void ApplyHistogram<
             T,
             TBinType,
             TLocator,
@@ -101,69 +58,7 @@ namespace ILGPU.Algorithms.Tests
                 out int[] expectedOverflow)
             where T : unmanaged
             where TBinType : unmanaged
-            where TLocator : struct, IComputeSingleBinOperation<T, Index1>
-            where TIncrementor : struct, IIncrementOperation<TBinType>
-        {
-            var numBins = histogram.Length;
-            TLocator operation = default;
-            TIncrementor increment = default;
-            var histogramOverflow = false;
-
-            foreach (var value in values)
-            {
-                var binIdx = operation.ComputeHistogramBin(value, numBins);
-                increment.Increment(ref histogram[binIdx], out var incrementOverflow);
-                histogramOverflow |= incrementOverflow;
-            }
-
-            expectedOverflow = new[] { histogramOverflow ? 1 : 0 };
-        }
-
-        [SuppressMessage(
-            "Performance",
-            "CA1814:Prefer jagged arrays over multidimensional")]
-        private static void ApplyHistogram2D<
-            T,
-            TBinType,
-            TLocator,
-            TIncrementor>(
-                TBinType[] histogram,
-                T[,] values,
-                out int[] expectedOverflow)
-            where T : unmanaged
-            where TBinType : unmanaged
-            where TLocator : struct, IComputeSingleBinOperation<T, Index1>
-            where TIncrementor : struct, IIncrementOperation<TBinType>
-        {
-            var numBins = histogram.Length;
-            TLocator operation = default;
-            TIncrementor increment = default;
-            var histogramOverflow = false;
-
-            foreach (var value in values)
-            {
-                var binIdx = operation.ComputeHistogramBin(value, numBins);
-                increment.Increment(ref histogram[binIdx], out var incrementOverflow);
-                histogramOverflow |= incrementOverflow;
-            }
-
-            expectedOverflow = new[] { histogramOverflow ? 1 : 0 };
-        }
-
-        [SuppressMessage(
-            "Performance",
-            "CA1814:Prefer jagged arrays over multidimensional")]
-        private static void ApplyHistogram3D<
-            T,
-            TBinType,
-            TLocator,
-            TIncrementor>(
-                TBinType[] histogram,
-                T[,,] values,
-                out int[] expectedOverflow)
-            where T : unmanaged
-            where TBinType : unmanaged
-            where TLocator : struct, IComputeSingleBinOperation<T, Index1>
+            where TLocator : struct, IComputeSingleBinOperation<T, Index1D>
             where TIncrementor : struct, IIncrementOperation<TBinType>
         {
             var numBins = histogram.Length;
@@ -187,9 +82,11 @@ namespace ILGPU.Algorithms.Tests
 
 <# foreach (var inputType in inputTypes) { #>
         internal readonly struct ModuloBin<#= inputType.Name #>Operation
-            : IComputeSingleBinOperation<<#= inputType.Type #>, Index1>
+            : IComputeSingleBinOperation<<#= inputType.Type #>, Index1D>
         {
-            public Index1 ComputeHistogramBin(<#= inputType.Type #> value, Index1 numBins) =>
+            public readonly Index1D ComputeHistogramBin(
+                <#= inputType.Type #> value,
+                Index1D numBins) =>
 <#      if (inputType.IsFloat) { #>
                 (int)XMath.Abs(XMath.Rem(value, numBins));
 <#      } else { #>
@@ -200,25 +97,18 @@ namespace ILGPU.Algorithms.Tests
 <# } #>
         #endregion
 
-<# for (int i = 1; i <= 3; ++i) { #>
-        #region Histogram <#= i #>D Tests
-
-<#      foreach (var inputType in inputTypes) { #>
-<#          foreach (var binType in incrementTypes) { #>
+<# foreach (var inputType in inputTypes) { #>
+<#      foreach (var binType in incrementTypes) { #>
         [Theory]
         [InlineData(64, 1024)]
         [InlineData(256, 1024)]
-        public void Histogram<#= i #>D_CreateBin<#= binType.Name #>From<#= inputType.Name #>(
+        public void Histogram_CreateBin<#= binType.Name #>From<#= inputType.Name #>(
             int numBins,
             int length)
         {
-<#              if (i > 1) { #>
-            length = (int)System.Math.Pow(length, 1.0 / <#= i #>.0);
-<#              } #>
-
-            var inputArray = InitializeInput<#= i #>D_<#= inputType.Name #>(length);
+            var inputArray = InitializeInput_<#= inputType.Name #>(length);
             var expected = new <#= binType.Type #>[numBins];
-            ApplyHistogram<#= i #>D<
+            ApplyHistogram<
                 <#= inputType.Type #>,
                 <#= binType.Type #>,
                 ModuloBin<#= inputType.Name #>Operation,
@@ -227,23 +117,20 @@ namespace ILGPU.Algorithms.Tests
                     inputArray,
                     out var expectedOverflow);
 
-            using var input = Accelerator.Allocate<<#= inputType.Type #>>(
-                new Index<#= i #>(length));
-            input.CopyFrom(
-                inputArray,
-                Index<#= i #>.Zero,
-                Index<#= i #>.Zero,
-                input.Extent);
+            using var input = Accelerator.Allocate1D<<#= inputType.Type #>>(
+                new Index1D(length));
+            input.CopyFromCPU(inputArray);
 
-            using var histogram = Accelerator.Allocate<<#= binType.Type #>>(numBins);
+            using var histogram = Accelerator.Allocate1D<<#= binType.Type #>>(numBins);
             histogram.MemSetToZero();
 
-            using var histogramOverflow = Accelerator.Allocate<int>(1);
+            using var histogramOverflow = Accelerator.Allocate1D<int>(1);
             histogramOverflow.MemSetToZero();
 
             Accelerator.Synchronize();
-            Accelerator.Histogram<#= i > 1 ? $"{i}D" : "" #><
+            Accelerator.Histogram<
                 <#= inputType.Type #>,
+                Stride1D.Dense,
                 ModuloBin<#= inputType.Name #>Operation>(
                     Accelerator.DefaultStream,
                     input.View,
@@ -251,24 +138,24 @@ namespace ILGPU.Algorithms.Tests
                     histogramOverflow.View);
             Accelerator.Synchronize();
 
-            Verify(histogram, expected);
-            Verify(histogramOverflow, expectedOverflow);
+            Verify(histogram.View, expected);
+            Verify(histogramOverflow.View, expectedOverflow);
         }
 
 <#              /*  NB: Disabled overflow test for floats as they are not reliable  */ #>
 <#              if (!binType.IsFloat) { #>
         [Fact]
-        public void HistogramOverflow<#= i #>D_CreateBin<#= binType.Name #>From<#= inputType.Name #>()
+        public void HistogramOverflow_CreateBin<#= binType.Name #>From<#= inputType.Name #>()
         {
             var length = 32;
-            var inputArray = InitializeInput<#= i #>D_<#= inputType.Name #>(length);
+            var inputArray = InitializeInput_<#= inputType.Name #>(length);
 
             // Prepare a histogram that is just about to overflow
             var expected = new <#= binType.Type #>[]
             {
-                <#= binType.Type #>.MaxValue - (<#= binType.Type #>)Math.Pow(length, <#= i #>) - 1
+                <#= binType.Type #>.MaxValue - (<#= binType.Type #>)length - 1
             };
-            ApplyHistogram<#= i #>D<
+            ApplyHistogram<
                 <#= inputType.Type #>,
                 <#= binType.Type #>,
                 ModuloBin<#= inputType.Name #>Operation,
@@ -277,26 +164,23 @@ namespace ILGPU.Algorithms.Tests
                     inputArray,
                     out var expectedOverflow1);
 
-            using var input = Accelerator.Allocate<<#= inputType.Type #>>(new Index<#= i #>(length));
-            input.CopyFrom(
-                inputArray,
-                Index<#= i #>.Zero,
-                Index<#= i #>.Zero,
-                input.Extent);
+            using var input = Accelerator.Allocate1D<<#= inputType.Type #>>(
+                new Index1D(length));
+            input.CopyFromCPU(inputArray);
 
-            using var histogram = Accelerator.Allocate<<#= binType.Type #>>(
+            using var histogram = Accelerator.Allocate1D<<#= binType.Type #>>(
                 expected.Length);
-            histogram.CopyFrom(expected, Index1.Zero, Index1.Zero, histogram.Extent);
+            histogram.CopyFromCPU(expected);
 
-            using var histogramOverflow = Accelerator.Allocate<int>(1);
+            using var histogramOverflow = Accelerator.Allocate1D<int>(1);
             histogramOverflow.MemSetToZero();
 
             // Check that the expected histogram has not yet overflowed
             Accelerator.Synchronize();
-            Verify(histogramOverflow, expectedOverflow1);
+            Verify(histogramOverflow.View, expectedOverflow1);
 
             // Apply the histogram operation one more time to generate an overflow
-            ApplyHistogram<#= i #>D<
+            ApplyHistogram<
                 <#= inputType.Type #>,
                 <#= binType.Type #>,
                 ModuloBin<#= inputType.Name #>Operation,
@@ -305,8 +189,9 @@ namespace ILGPU.Algorithms.Tests
                     inputArray,
                     out var expectedOverflow2);
 
-            Accelerator.Histogram<#= i > 1 ? $"{i}D" : "" #><
+            Accelerator.Histogram<
                 <#= inputType.Type #>,
+                Stride1D.Dense,
                 ModuloBin<#= inputType.Name #>Operation>(
                     Accelerator.DefaultStream,
                     input.View,
@@ -314,13 +199,11 @@ namespace ILGPU.Algorithms.Tests
                     histogramOverflow.View);
             Accelerator.Synchronize();
 
-            Verify(histogram, expected);
-            Verify(histogramOverflow, expectedOverflow2);
+            Verify(histogram.View, expected);
+            Verify(histogramOverflow.View, expectedOverflow2);
         }
-<#              } #>
 <#          } #>
 <#      } #>
-        #endregion
 
 <# } #>
     }

--- a/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
+++ b/Src/ILGPU.Algorithms.Tests/ILGPU.Algorithms.Tests.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' AND '$(GITHUB_ACTIONS)' == 'true'">
+    <TargetFrameworks>$(TargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Channel)' == 'experimental'">
@@ -34,6 +38,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
@@ -331,6 +336,4 @@
   <ItemGroup>
     <Folder Include="Generic\" />
   </ItemGroup>
-
-  <Import Project="..\..\ILGPU\Src\TextTransform.targets" />
 </Project>

--- a/Src/ILGPU.Algorithms.Tests/InitializeTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/InitializeTests.cs
@@ -102,13 +102,13 @@ namespace ILGPU.Algorithms.Tests
         public void InitializeSimple<T, TArraySize>(T value, int size)
             where T : unmanaged
         {
-            using var buffer = Accelerator.Allocate<T>(size);
+            using var buffer = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
             Accelerator.Initialize(stream, buffer.View, value);
 
             stream.Synchronize();
             var expected = Enumerable.Repeat(value, size).ToArray();
-            Verify(buffer, expected);
+            Verify(buffer.View, expected);
         }
     }
 }

--- a/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/RadixSortExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Algorithms.RadixSortOperations;
 using ILGPU.Runtime;
@@ -144,7 +143,7 @@ namespace ILGPU.Algorithms.Tests
             where TRadixSortOp : struct, IRadixSortOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
 <#
@@ -160,23 +159,17 @@ namespace ILGPU.Algorithms.Tests
 <#
             }
 #>
-            input.CopyFrom(
-                stream,
-                sequence,
-                0,
-                0,
-                length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
 
             var radixSort = Accelerator.CreateRadixSort<T, TRadixSortOp>();
             var tempMemSize =
                 Accelerator.ComputeRadixSortTempStorageSize<T, TRadixSortOp>(length);
-            using var tmpBuffer = Accelerator.Allocate<int>(tempMemSize);
+            using var tmpBuffer = Accelerator.Allocate1D<int>(tempMemSize);
 
             radixSort(stream, input.View, tmpBuffer.View);
             stream.Synchronize();
 
-            Verify(input, expected);
+            Verify(input.View, expected);
         }
 
         [Theory]
@@ -192,7 +185,7 @@ namespace ILGPU.Algorithms.Tests
             where TRadixSortOp : struct, IRadixSortOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
 <#
@@ -206,23 +199,17 @@ namespace ILGPU.Algorithms.Tests
 <#
             }
 #>
-            input.CopyFrom(
-                stream,
-                sequence,
-                0,
-                0,
-                length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
 
             var radixSort = Accelerator.CreateRadixSort<T, TRadixSortOp>();
             var tempMemSize =
                 Accelerator.ComputeRadixSortTempStorageSize<T, TRadixSortOp>(length);
-            using var tmpBuffer = Accelerator.Allocate<int>(tempMemSize);
+            using var tmpBuffer = Accelerator.Allocate1D<int>(tempMemSize);
 
             radixSort(stream, input.View, tmpBuffer.View);
             stream.Synchronize();
 
-            Verify(input, sequence);
+            Verify(input.View, sequence);
         }
 
         [Theory]
@@ -241,7 +228,7 @@ namespace ILGPU.Algorithms.Tests
             where TRadixSortOp : struct, IRadixSortOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
 <#
@@ -257,13 +244,7 @@ namespace ILGPU.Algorithms.Tests
 <#
             }
 #>
-            input.CopyFrom(
-                stream,
-                sequence,
-                0,
-                0,
-                length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
             
             using var radixSortProvider = Accelerator.CreateRadixSortProvider();
             var radixSortUsingSortProvider =
@@ -272,7 +253,7 @@ namespace ILGPU.Algorithms.Tests
             radixSortUsingSortProvider(stream, input.View);
             stream.Synchronize();
 
-            Verify(input, expected);
+            Verify(input.View, expected);
         }
 
         [Theory]
@@ -288,7 +269,7 @@ namespace ILGPU.Algorithms.Tests
             where TRadixSortOp : struct, IRadixSortOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
 <#
@@ -302,13 +283,7 @@ namespace ILGPU.Algorithms.Tests
 <#
             }
 #>
-            input.CopyFrom(
-                stream,
-                sequence,
-                0,
-                0,
-                length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
             
             using var radixSortProvider = Accelerator.CreateRadixSortProvider();
             var radixSortUsingSortProvider =
@@ -317,7 +292,7 @@ namespace ILGPU.Algorithms.Tests
             radixSortUsingSortProvider(stream, input.View);
             stream.Synchronize();
 
-            Verify(input, sequence);
+            Verify(input.View, sequence);
         }
 
         [Theory]
@@ -333,8 +308,8 @@ namespace ILGPU.Algorithms.Tests
             where TRadixSortOp : struct, IRadixSortOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var keys = Accelerator.Allocate<T>(length);
-            using var values = Accelerator.Allocate<T>(length);
+            using var keys = Accelerator.Allocate1D<T>(length);
+            using var values = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
             var sourceSequence = sequencer.ComputeSequence(start, stepSize, length);
@@ -347,31 +322,20 @@ namespace ILGPU.Algorithms.Tests
             Util.Utilities.Swap(ref sourceSequence, ref targetSequence);
 <#      } #>
 
-            keys.CopyFrom(
-                stream,
-                sourceSequence,
-                0,
-                0,
-                length);
-            values.CopyFrom(
-                stream,
-                sourceSequence,
-                0,
-                0,
-                length);
-            stream.Synchronize();
+            keys.CopyFromCPU(stream, sourceSequence);
+            values.CopyFromCPU(stream, sourceSequence);
 
             var radixSort = Accelerator.CreateRadixSortPairs<T, T, TRadixSortOp>();
             var tempMemSize =
                 Accelerator.ComputeRadixSortPairsTempStorageSize<T, T, TRadixSortOp>(
                     length);
-            using var tmpBuffer = Accelerator.Allocate<int>(tempMemSize);
+            using var tmpBuffer = Accelerator.Allocate1D<int>(tempMemSize);
 
             radixSort(stream, keys.View, values.View, tmpBuffer.View);
             stream.Synchronize();
 
-            Verify(keys, targetSequence);
-            Verify(values, targetSequence);
+            Verify(keys.View, targetSequence);
+            Verify(values.View, targetSequence);
         }
 
 <#
@@ -390,22 +354,21 @@ namespace ILGPU.Algorithms.Tests
             where TRadixSortOp : struct, IRadixSortOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
             var sequence = sequencer.ComputeSequence(start, stepSize, length);
-            input.CopyFrom(stream, sequence, 0, 0, length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
 
             var radixSort = Accelerator.CreateRadixSort<T, TRadixSortOp>();
             var tempMemSize =
                 Accelerator.ComputeRadixSortTempStorageSize<T, TRadixSortOp>(length);
-            using var tmpBuffer = Accelerator.Allocate<int>(tempMemSize);
+            using var tmpBuffer = Accelerator.Allocate1D<int>(tempMemSize);
 
             radixSort(stream, input.View, tmpBuffer.View);
             stream.Synchronize();
 
-            Verify(input, sequence);
+            Verify(input.View, sequence);
         }
 
         [Theory]
@@ -421,12 +384,11 @@ namespace ILGPU.Algorithms.Tests
             where TRadixSortOp : struct, IRadixSortOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
             var sequence = sequencer.ComputeSequence(start, stepSize, length);
-            input.CopyFrom(stream, sequence, 0, 0, length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
 
             using var radixSortProvider = Accelerator.CreateRadixSortProvider();
             var radixSortUsingSortProvider =
@@ -435,7 +397,7 @@ namespace ILGPU.Algorithms.Tests
             radixSortUsingSortProvider(stream, input.View);
             stream.Synchronize();
 
-            Verify(input, sequence);
+            Verify(input.View, sequence);
         }
     }
 }

--- a/Src/ILGPU.Algorithms.Tests/RandomTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/RandomTests.tt
@@ -59,7 +59,8 @@ namespace ILGPU.Algorithms.Tests
             int size)
             where TRandomProvider : unmanaged, IRandomProvider<TRandomProvider>
         {
-            using var buffer = Accelerator.AllocateZero<<#= randomType #>>(size);
+            using var buffer = Accelerator.Allocate1D<<#= randomType #>>(size);
+            buffer.MemSetToZero();
             Accelerator.Synchronize();
 
             var random = new System.Random(42);
@@ -72,7 +73,7 @@ namespace ILGPU.Algorithms.Tests
             // The current RNG implementation does not yield zeros when using the
             // initial RNG seed 42. Moreover, it should yield more than length / 2
             // number of different values
-            var data = buffer.GetAsArray();
+            var data = buffer.GetAs1DArray();
             var dataSet = new HashSet<<#= randomType #>>(data);
             Assert.True(dataSet.Count > data.Length / 2);
         }

--- a/Src/ILGPU.Algorithms.Tests/ReductionExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ReductionExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Algorithms.ScanReduceOperations;
 using ILGPU.Runtime;
@@ -122,7 +121,7 @@ namespace ILGPU.Algorithms.Tests
             where TReduceFunc : struct, IScanReduceOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
 
 <#
@@ -136,14 +135,9 @@ namespace ILGPU.Algorithms.Tests
 <#
             }
 #>
-            input.CopyFrom(
-                stream,
-                sequence,
-                0,
-                0,
-                length);
+            input.CopyFromCPU(stream, sequence);
 
-            T actual = Accelerator.Reduce<T, TReduceFunc>(stream, input);
+            T actual = Accelerator.Reduce<T, TReduceFunc>(stream, input.View);
             stream.Synchronize();
             T expected = CalcValue(sequence, func.Apply);
 
@@ -166,8 +160,8 @@ namespace ILGPU.Algorithms.Tests
             where TReduceFunc : struct, IScanReduceOperation<T>
             where TSequencer : struct, ITestSequencer<T>
         {
-            using var input = Accelerator.Allocate<T>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
             using var stream = Accelerator.CreateStream();
             
 <#
@@ -181,20 +175,15 @@ namespace ILGPU.Algorithms.Tests
 <#
             }
 #>
-            input.CopyFrom(
-                stream,
-                sequence,
-                0,
-                0,
-                length);
+            input.CopyFromCPU(stream, sequence);
 
-            Accelerator.Reduce<T, TReduceFunc>(stream, input, output);
+            Accelerator.Reduce<T, TReduceFunc>(stream, input.View, output.View);
             stream.Synchronize();
 
             T[] expected = new T[1];
             expected[0] = CalcValue(sequence, func.Apply);
 
-            Verify(output, expected, 0, 1);
+            Verify(output.View, expected, 0, 1);
         }
 <#
         }

--- a/Src/ILGPU.Algorithms.Tests/ReorderExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ReorderExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Runtime;
 using ILGPU.Tests;
@@ -120,22 +119,22 @@ namespace ILGPU.Algorithms.Tests
             where TTransform : struct, ITransformer<T, T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<T>(length);
-            using var reorder = Accelerator.Allocate<Index1>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var reorder = Accelerator.Allocate1D<Index1D>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
             var indexSequencer = new Index1TestSequencer();
             var reorderSeq = indexSequencer.ComputeSequence(length - 1, -1, length);
 
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
-            reorder.CopyFrom(stream, reorderSeq, 0, 0, length);
+            input.CopyFromCPU(stream, inputSeq);
+            reorder.CopyFromCPU(stream, reorderSeq);
 
-            Accelerator.Reorder(stream, input.View, output.View, reorder.View);
+            Accelerator.Reorder<T>(stream, input.View, output.View, reorder.View);
             stream.Synchronize();
 
             Verify(
-                output,
+                output.View,
                 CalcValues<T, T, IdentityTransformer<T>>(
                     inputSeq,
                     reorderSeq,
@@ -156,16 +155,16 @@ namespace ILGPU.Algorithms.Tests
             where TTransform : struct, ITransformer<T, T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<T>(length);
-            using var reorder = Accelerator.Allocate<Index1>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var reorder = Accelerator.Allocate1D<Index1D>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
             var indexSequencer = new Index1TestSequencer();
             var reorderSeq = indexSequencer.ComputeSequence(length - 1, -1, length);
 
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
-            reorder.CopyFrom(stream, reorderSeq, 0, 0, length);
+            input.CopyFromCPU(stream, inputSeq);
+            reorder.CopyFromCPU(stream, reorderSeq);
 
             var reTrans = Accelerator.CreateReorderTransformer<T, T, TTransform>();
             reTrans(
@@ -177,7 +176,7 @@ namespace ILGPU.Algorithms.Tests
             stream.Synchronize();
 
             Verify(
-                output,
+                output.View,
                 CalcValues<T, T, TTransform>( inputSeq, reorderSeq, transformer));
         }
 
@@ -195,16 +194,16 @@ namespace ILGPU.Algorithms.Tests
             where TTransform : struct, ITransformer<T, T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<T>(length);
-            using var reorder = Accelerator.Allocate<Index1>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var reorder = Accelerator.Allocate1D<Index1D>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
             var indexSequencer = new Index1TestSequencer();
             var reorderSeq = indexSequencer.ComputeSequence(length - 1, -1, length);
 
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
-            reorder.CopyFrom(stream, reorderSeq, 0, 0, length);
+            input.CopyFromCPU(stream, inputSeq);
+            reorder.CopyFromCPU(stream, reorderSeq);
 
             Accelerator.ReorderTransform<T, TTransform>(
                 stream,
@@ -215,7 +214,7 @@ namespace ILGPU.Algorithms.Tests
             stream.Synchronize();
 
             Verify(
-                output,
+                output.View,
                 CalcValues<T, T, TTransform>(inputSeq, reorderSeq, transformer));
         }
 
@@ -239,18 +238,18 @@ namespace ILGPU.Algorithms.Tests
             where TTransform : struct, ITransformer<TSource, TTarget>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<TSource>(length);
-            using var reorder = Accelerator.Allocate<Index1>(length);
-            using var output = Accelerator.Allocate<TTarget>(length);
+            using var input = Accelerator.Allocate1D<TSource>(length);
+            using var reorder = Accelerator.Allocate1D<Index1D>(length);
+            using var output = Accelerator.Allocate1D<TTarget>(length);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
             var indexSequencer = new Index1TestSequencer();
             var reorderSeq = indexSequencer.ComputeSequence(length - 1, -1, length);
 
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
-            reorder.CopyFrom(stream, reorderSeq, 0, 0, length);
+            input.CopyFromCPU(stream, inputSeq);
+            reorder.CopyFromCPU(stream, reorderSeq);
 
-            Accelerator.ReorderTransform(
+            Accelerator.ReorderTransform<TSource, TTarget, TTransform>(
                 stream,
                 input.View,
                 output.View,
@@ -259,7 +258,7 @@ namespace ILGPU.Algorithms.Tests
             stream.Synchronize();
 
             Verify(
-                output,
+                output.View,
                 CalcValues<TSource, TTarget, TTransform>(
                     inputSeq,
                     reorderSeq,
@@ -270,7 +269,7 @@ namespace ILGPU.Algorithms.Tests
 
         private static TTarget[] CalcValues<TSource, TTarget, TTransform>(
             TSource[] input,
-            Index1[] order,
+            Index1D[] order,
             TTransform transform)
             where TSource : unmanaged
             where TTarget : unmanaged

--- a/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/ScanExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Algorithms.ScanReduceOperations;
 using ILGPU.Runtime;
@@ -126,23 +125,22 @@ namespace ILGPU.Algorithms.Tests
             where TScanFunc : struct, IScanReduceOperation<T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<T>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
             
             var tmpMemSize = Accelerator.ComputeScanTempStorageSize<T>(output.Length);
-            using var tmp = Accelerator.Allocate<int>(tmpMemSize);
+            using var tmp = Accelerator.Allocate1D<int>(tmpMemSize);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, inputSeq);
 
             var scan = Accelerator.CreateInclusiveScan<T, TScanFunc>();
 
-            scan(stream, input.View, output.View, tmp);
+            scan(stream, input.View, output.View, tmp.View);
             stream.Synchronize();
 
             var expected = CalcValues(inputSeq, func, ScanKind.Inclusive);
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
 
 <#
@@ -168,23 +166,22 @@ namespace ILGPU.Algorithms.Tests
             where TScanFunc : struct, IScanReduceOperation<T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<T>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
             
             var tmpMemSize = Accelerator.ComputeScanTempStorageSize<T>(output.Length);
-            using var tmp = Accelerator.Allocate<int>(tmpMemSize);
+            using var tmp = Accelerator.Allocate1D<int>(tmpMemSize);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, inputSeq);
 
             var scan = Accelerator.CreateExclusiveScan<T, TScanFunc>();
 
-            scan(stream, input.View, output.View, tmp);
+            scan(stream, input.View, output.View, tmp.View);
             stream.Synchronize();
 
             var expected = CalcValues(inputSeq, func, ScanKind.Exclusive);
-            Verify(output, expected);
+            Verify(output.View, expected);
         } 
 
 <#
@@ -207,21 +204,21 @@ namespace ILGPU.Algorithms.Tests
             where TScanFunc : struct, IScanReduceOperation<T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<T>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
+            input.CopyFromCPU(stream, inputSeq);
 
             using var scanProvider = Accelerator.CreateScanProvider();
             var scan = scanProvider.CreateExclusiveScan<T, TScanFunc>();
             stream.Synchronize();
 
-            scan(stream, input, output);
+            scan(stream, input.View, output.View);
             stream.Synchronize();
             
             var expected = CalcValues(inputSeq, func, ScanKind.Exclusive);
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
 
         [Theory]
@@ -240,21 +237,21 @@ namespace ILGPU.Algorithms.Tests
             where TScanFunc : struct, IScanReduceOperation<T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<T>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<T>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
 
             var inputSeq = sequencer.ComputeSequence(start, stepSize, length);
-            input.CopyFrom(stream, inputSeq, 0, 0, length);
+            input.CopyFromCPU(stream, inputSeq);
 
             using var scanProvider = Accelerator.CreateScanProvider();
             var scan = scanProvider.CreateInclusiveScan<T, TScanFunc>();
             stream.Synchronize();
 
-            scan(stream, input, output);
+            scan(stream, input.View, output.View);
             stream.Synchronize();
             
             var expected = CalcValues(inputSeq, func, ScanKind.Inclusive);
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
 
         #region Helper Methods

--- a/Src/ILGPU.Algorithms.Tests/SequencerTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/SequencerTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Algorithms.Sequencers;
 using ILGPU.Runtime;
@@ -46,16 +45,19 @@ namespace ILGPU.Algorithms.Tests
         [MemberData(nameof(TestDataLength))]
         public void SequencerIndex1(int bufferLength)
         {
-            using var buffer = Accelerator.Allocate<Index1>(bufferLength);
+            using var buffer = Accelerator.Allocate1D<Index1D>(bufferLength);
             using var stream = Accelerator.CreateStream();
-            Accelerator.Sequence(stream, buffer.View, new IndexSequencer());
+            Accelerator.Sequence(
+                stream,
+                buffer.View.AsContiguous(),
+                new IndexSequencer());
 
-            Index1[] expected = new Index1[bufferLength];
+            Index1D[] expected = new Index1D[bufferLength];
             for (int i = 0, e = bufferLength; i < e; ++i)
                 expected[i] = i;
 
             stream.Synchronize();
-            Verify(buffer, expected);
+            Verify(buffer.View, expected);
         }
 
 <#
@@ -65,9 +67,12 @@ namespace ILGPU.Algorithms.Tests
         [MemberData(nameof(TestDataLength))]
         public void Sequencer<#= type.Name #>(int bufferLength)
         {
-            using var buffer = Accelerator.Allocate<<#= type.Type #>>(bufferLength);
+            using var buffer = Accelerator.Allocate1D<<#= type.Type #>>(bufferLength);
             using var stream = Accelerator.CreateStream();
-            Accelerator.Sequence(stream, buffer.View, new <#= type.Name #>Sequencer());
+            Accelerator.Sequence(
+                stream,
+                buffer.View.AsContiguous(),
+                new <#= type.Name #>Sequencer());
 
             <#= type.Type #>[] expected = new <#= type.Type #>[bufferLength];
             for (int i = 0, e = bufferLength; i < e; ++i)
@@ -77,21 +82,21 @@ namespace ILGPU.Algorithms.Tests
 <# if (verifyWithinRelativeErrorMap.TryGetValue(type.Name, out var relativeError)) { #>
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
-                    buffer,
+                    buffer.View,
                     expected,
                     <#= relativeError.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
                 VerifyWithinRelativeError(
-                    buffer,
+                    buffer.View,
                     expected,
                     <#= relativeError.OpenCL #>);
             else
                 VerifyWithinRelativeError(
-                    buffer,
+                    buffer.View,
                     expected,
                     <#= relativeError.CPU #>);
 <# } else { #>
-            Verify(buffer, expected);
+            Verify(buffer.View, expected);
 <# } #>
         }
 
@@ -106,11 +111,11 @@ namespace ILGPU.Algorithms.Tests
         [MemberData(nameof(TestDataLength))]
         public void RepeatedSequencer<#= type.Name #>(int bufferLength)
         {
-            using var buffer = Accelerator.Allocate<<#= type.Type #>>(bufferLength);
+            using var buffer = Accelerator.Allocate1D<<#= type.Type #>>(bufferLength);
             using var stream = Accelerator.CreateStream();
             Accelerator.RepeatedSequence(
                 stream,
-                buffer.View,
+                buffer.View.AsContiguous(),
                 2,
                 new <#= type.Name #>Sequencer());
 
@@ -120,7 +125,7 @@ namespace ILGPU.Algorithms.Tests
                 expected[i + j] = (<#= type.Type #>)j;
 
             stream.Synchronize();
-            Verify(buffer, expected);
+            Verify(buffer.View, expected);
         }
 
 <#
@@ -134,11 +139,11 @@ namespace ILGPU.Algorithms.Tests
         [MemberData(nameof(TestDataLength))]
         public void BatchedSequencer<#= type.Name #>(int bufferLength)
         {
-            using var buffer = Accelerator.Allocate<<#= type.Type #>>(bufferLength);
+            using var buffer = Accelerator.Allocate1D<<#= type.Type #>>(bufferLength);
             using var stream = Accelerator.CreateStream();
             Accelerator.BatchedSequence(
                 stream,
-                buffer.View,
+                buffer.View.AsContiguous(),
                 2,
                 new <#= type.Name #>Sequencer());
 
@@ -151,21 +156,21 @@ namespace ILGPU.Algorithms.Tests
 <# if (verifyWithinRelativeErrorMap.TryGetValue(type.Name, out var relativeError)) { #>
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
-                    buffer,
+                    buffer.View,
                     expected,
                     <#= relativeError.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
                 VerifyWithinRelativeError(
-                    buffer,
+                    buffer.View,
                     expected,
                     <#= relativeError.OpenCL #>);
             else
                 VerifyWithinRelativeError(
-                    buffer,
+                    buffer.View,
                     expected,
                     <#= relativeError.CPU #>);
 <# } else { #>
-            Verify(buffer, expected);
+            Verify(buffer.View, expected);
 <# } #>
         }
 
@@ -181,11 +186,11 @@ namespace ILGPU.Algorithms.Tests
         [MemberData(nameof(TestDataLength))]
         public void RepeatedBatchedSequencer<#= type.Name #>(int bufferLength)
         {
-            using var buffer = Accelerator.Allocate<<#= type.Type #>>(bufferLength);
+            using var buffer = Accelerator.Allocate1D<<#= type.Type #>>(bufferLength);
             using var stream = Accelerator.CreateStream();
             Accelerator.RepeatedBatchedSequence(
                 stream,
-                buffer.View,
+                buffer.View.AsContiguous(),
                 2,
                 4,
                 new <#= type.Name #>Sequencer());
@@ -197,7 +202,7 @@ namespace ILGPU.Algorithms.Tests
                         expected[i + j * 4 + k] = (<#= type.Type #>)(j);
 
             stream.Synchronize();
-            Verify(buffer, expected);
+            Verify(buffer.View, expected);
         }
 
 <#

--- a/Src/ILGPU.Algorithms.Tests/TempViewManagerTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/TempViewManagerTests.cs
@@ -1,7 +1,6 @@
 ﻿using ILGPU.Tests;
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -42,8 +41,8 @@ namespace ILGPU.Algorithms.Tests
             where T : unmanaged
         {
             var length = Interop.ComputeRelativeSizeOf<int, T>(1) * 2;
-            using var buffer = Accelerator.Allocate<int>(length);
-            var viewManager = new TempViewManager(buffer, nameof(buffer));
+            using var buffer = Accelerator.Allocate1D<int>(length);
+            var viewManager = new TempViewManager(buffer.View, nameof(buffer));
 
             viewManager.Allocate<T>(1);
             viewManager.Allocate<T>(1);
@@ -65,8 +64,8 @@ namespace ILGPU.Algorithms.Tests
                 return;
 
             var length = Interop.ComputeRelativeSizeOf<int, T>(1) + 1;
-            using var buffer = Accelerator.Allocate<int>(length);
-            var viewManager = new TempViewManager(buffer, nameof(buffer));
+            using var buffer = Accelerator.Allocate1D<int>(length);
+            var viewManager = new TempViewManager(buffer.View, nameof(buffer));
 
             viewManager.Allocate<byte>(1);
             Assert.Throws<InvalidOperationException>(() =>

--- a/Src/ILGPU.Algorithms.Tests/TransformerExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/TransformerExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Runtime;
 using ILGPU.Tests;
@@ -58,12 +57,12 @@ namespace ILGPU.Algorithms.Tests
         public void TransformToNegativeTest(int length)
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<int>(length);
-            using var output = Accelerator.Allocate<int>(length);
+            using var input = Accelerator.Allocate1D<int>(length);
+            using var output = Accelerator.Allocate1D<int>(length);
             
             var sequencer = new Int32TestSequencer();
             var sequence = sequencer.ComputeSequence(42, 0, length);
-            input.CopyFrom(stream, sequence, 0, 0, length);
+            input.CopyFromCPU(stream, sequence);
 
             Accelerator.Transform<int, IntToNegIntTransformer>(
                 stream, 
@@ -72,7 +71,7 @@ namespace ILGPU.Algorithms.Tests
                 new IntToNegIntTransformer());
 
             stream.Synchronize();
-            Verify(output, sequence.Select(x => -x).ToArray());
+            Verify(output.View, sequence.Select(x => -x).ToArray());
         }
 
         [Theory]
@@ -80,22 +79,23 @@ namespace ILGPU.Algorithms.Tests
         public void TransformIntToLongTest(int length)
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<int>(length);
-            using var output = Accelerator.Allocate<long>(length);
+            using var input = Accelerator.Allocate1D<int>(length);
+            using var output = Accelerator.Allocate1D<long>(length);
 
             var sequencer = new Int32TestSequencer();
             var sequence = sequencer.ComputeSequence(42, 0, length);
-            input.CopyFrom(stream, sequence, 0, 0, length);
+            input.CopyFromCPU(stream, sequence);
 
             var transformer =
                 Accelerator.CreateTransformer<int, long, IntToLongTransformer>();
-            transformer(stream,
+            transformer(
+                stream,
                 input.View,
                 output.View,
                 new IntToLongTransformer());
 
             stream.Synchronize();
-            Verify(output, sequence.Select(x => (long)x).ToArray());
+            Verify(output.View, sequence.Select(x => (long)x).ToArray());
         }
 
         [Theory]
@@ -103,12 +103,12 @@ namespace ILGPU.Algorithms.Tests
         public void TransformUInt32ToBitCompIntTest(int length)
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<uint>(length);
-            using var output = Accelerator.Allocate<int>(length);
+            using var input = Accelerator.Allocate1D<uint>(length);
+            using var output = Accelerator.Allocate1D<int>(length);
 
             var sequencer = new UInt32TestSequencer();
             var sequence = sequencer.ComputeSequence(0, 1, length);
-            input.CopyFrom(stream, sequence, 0, 0, length);
+            input.CopyFromCPU(stream, sequence);
 
             Accelerator.Transform(
                 stream,
@@ -117,7 +117,7 @@ namespace ILGPU.Algorithms.Tests
                 new UInt32ToBitCompInt32Transformer());
 
             stream.Synchronize();
-            Verify(output, sequence.Select(x => (int)~x).ToArray());
+            Verify(output.View, sequence.Select(x => (int)~x).ToArray());
         }
 
         [Theory]
@@ -127,20 +127,24 @@ namespace ILGPU.Algorithms.Tests
             TTransformer transformer,
             int length)
             where T : unmanaged
-            where TTransformer : struct, ITransformer<Index1, T>
+            where TTransformer : struct, ITransformer<Index1D, T>
         {
             using var stream = Accelerator.CreateStream();
-            using var input = Accelerator.Allocate<Index1>(length);
-            using var output = Accelerator.Allocate<T>(length);
+            using var input = Accelerator.Allocate1D<Index1D>(length);
+            using var output = Accelerator.Allocate1D<T>(length);
 
             var sequencer = new Index1TestSequencer();
             var sequence = sequencer.ComputeSequence(0, 1, length);
-            input.CopyFrom(stream, sequence, 0, 0, length);
+            input.CopyFromCPU(stream, sequence);
 
-            Accelerator.Transform(stream, input.View, output.View, transformer);
+            Accelerator.Transform<Index1D, T, TTransformer>(
+                stream,
+                input.View,
+                output.View,
+                transformer);
 
             stream.Synchronize();
-            Verify(output, sequence.Select(x => transformer.Transform(x)).ToArray());
+            Verify(output.View, sequence.Select(x => transformer.Transform(x)).ToArray());
         }
     }
 }

--- a/Src/ILGPU.Algorithms.Tests/UniqueExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/UniqueExtensionTests.tt
@@ -59,12 +59,12 @@ namespace ILGPU.Algorithms.Tests
                 .ToArray();
             var expected = RemoveConsecutiveDuplicates(inputArray);
 
-            using var input = Accelerator.Allocate(inputArray);
+            using var input = Accelerator.Allocate1D(inputArray);
             var result = Accelerator.Unique(Accelerator.DefaultStream, input.View);
             Assert.True(result < int.MaxValue);
             var resultLength = (int)result;
 
-            Verify(input, expected, length: resultLength);
+            Verify(input.View, expected, length: resultLength);
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms.Tests/VectorTests.cs
+++ b/Src/ILGPU.Algorithms.Tests/VectorTests.cs
@@ -49,29 +49,29 @@ namespace ILGPU.Algorithms.Tests
         #region Kernels
 
         internal static void Vector2dAddKernel(
-            Index1 index,
-            ArrayView<Vector2> input,
+            Index1D index,
+            ArrayView1D<Vector2, Stride1D.Dense> input,
             Vector2 operand)
         {
-            var target = input.GetVariableView(index);
+            var target = input.VariableView(index);
             target.AtomicAdd(operand);
         }
 
         internal static void Vector3dAddKernel(
-            Index1 index,
-            ArrayView<Vector3> input,
+            Index1D index,
+            ArrayView1D<Vector3, Stride1D.Dense> input,
             Vector3 operand)
         {
-            var target = input.GetVariableView(index);
+            var target = input.VariableView(index);
             target.AtomicAdd(operand);
         }
 
         internal static void Vector4dAddKernel(
-            Index1 index,
-            ArrayView<Vector4> input,
+            Index1D index,
+            ArrayView1D<Vector4, Stride1D.Dense> input,
             Vector4 operand)
         {
-            var target = input.GetVariableView(index);
+            var target = input.VariableView(index);
             target.AtomicAdd(operand);
         }
 
@@ -84,15 +84,14 @@ namespace ILGPU.Algorithms.Tests
             where TVector : struct, IVector<Vector2>
         {
             using var stream = Accelerator.CreateStream();
-            using var targetBuffer = Accelerator.Allocate<Vector2>(size);
+            using var targetBuffer = Accelerator.Allocate1D<Vector2>(size);
 
             var sequencer = new Vector2DSequencer();
             var sequence = sequencer.ComputeSequence(
                 new Vector2(0, size - 1),
                 new Vector2(1, -1),
                 size);
-            targetBuffer.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            targetBuffer.CopyFromCPU(stream, sequence);
             
             Execute(targetBuffer.Length, targetBuffer.View, vector.GetVector());
 
@@ -100,7 +99,7 @@ namespace ILGPU.Algorithms.Tests
             for (int i = 0; i < size; ++i)
                 expected[i] = new Vector2(i, size - 1 - i) + vector.GetVector();
 
-            Verify(targetBuffer, expected);
+            Verify(targetBuffer.View, expected);
         }
 
         [Theory]
@@ -109,7 +108,7 @@ namespace ILGPU.Algorithms.Tests
         public void Vector3dAdd<TVector>(int size, TVector vector)
             where TVector : struct, IVector<Vector3>
         {
-            using var targetBuffer = Accelerator.Allocate<Vector3>(size);
+            using var targetBuffer = Accelerator.Allocate1D<Vector3>(size);
             using var stream = Accelerator.CreateStream();
 
             var sequencer = new Vector3DSequencer();
@@ -117,8 +116,7 @@ namespace ILGPU.Algorithms.Tests
                 new Vector3(0, size - 1, 0),
                 new Vector3(1, -1, 1),
                 size);
-            targetBuffer.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            targetBuffer.CopyFromCPU(stream, sequence);
 
             Execute(targetBuffer.Length, targetBuffer.View, vector.GetVector());
 
@@ -126,7 +124,7 @@ namespace ILGPU.Algorithms.Tests
             for (int i = 0; i < size; ++i)
                 expected[i] = new Vector3(i, size - 1 - i, i) + vector.GetVector();
 
-            Verify(targetBuffer, expected);
+            Verify(targetBuffer.View, expected);
         }
 
         [Theory]
@@ -135,7 +133,7 @@ namespace ILGPU.Algorithms.Tests
         public void Vector4dAdd<TVector>(int size, TVector vector)
             where TVector : struct, IVector<Vector4>
         {
-            using var targetBuffer = Accelerator.Allocate<Vector4>(size);
+            using var targetBuffer = Accelerator.Allocate1D<Vector4>(size);
             using var stream = Accelerator.CreateStream();
 
             var sequencer = new Vector4DSequencer();
@@ -143,8 +141,7 @@ namespace ILGPU.Algorithms.Tests
                 new Vector4(0, size - 1, 0, 0),
                 new Vector4(1, -1, 1, 0),
                 size);
-            targetBuffer.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            targetBuffer.CopyFromCPU(stream, sequence);
 
             Execute(targetBuffer.Length, targetBuffer.View, vector.GetVector());
 
@@ -152,7 +149,7 @@ namespace ILGPU.Algorithms.Tests
             for (int i = 0; i < size; ++i)
                 expected[i] = new Vector4(i, size - 1 - i, i, 0) + vector.GetVector();
 
-            Verify(targetBuffer, expected);
+            Verify(targetBuffer.View, expected);
         }
 
         [Theory]
@@ -162,9 +159,9 @@ namespace ILGPU.Algorithms.Tests
         public void Index2Vector2Conv(float x, float y)
         {
             Vector2 initVector = new Vector2(x, y);
-            Index2 initIndex = new Index2((int)x, (int)y);
+            Index2D initIndex = new Index2D((int)x, (int)y);
 
-            Index2 index = initVector.ToIndex();
+            Index2D index = initVector.ToIndex();
             Vector2 vector = index.ToVector();
 
             Assert.Equal(initVector, vector);
@@ -178,9 +175,9 @@ namespace ILGPU.Algorithms.Tests
         public void Index3Vector3Conv(float x, float y, float z)
         {
             Vector3 initVector = new Vector3(x, y, z);
-            Index3 initIndex = new Index3((int)x, (int)y, (int)z);
+            Index3D initIndex = new Index3D((int)x, (int)y, (int)z);
 
-            Index3 index = initVector.ToIndex();
+            Index3D index = initVector.ToIndex();
             Vector3 vector = index.ToVector();
 
             Assert.Equal(initVector, vector);

--- a/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
+++ b/Src/ILGPU.Algorithms.Tests/WarpExtensionTests.tt
@@ -2,7 +2,6 @@
 <#@ include file="Generic/ConfigurationBase.tt" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 
 using ILGPU.Algorithms.ScanReduceOperations;
 using ILGPU.Runtime;
@@ -32,8 +31,8 @@ namespace ILGPU.Algorithms.Tests
         foreach (var func in WarpFunctions) {
 #>
         internal static void <#= func #>Kernel<T, TFunction>(
-            ArrayView<T> input,
-            ArrayView<T> output)
+            ArrayView1D<T, Stride1D.Dense> input,
+            ArrayView1D<T, Stride1D.Dense> output)
             where T : unmanaged
             where TFunction : unmanaged, IScanReduceOperation<T>
         {
@@ -105,17 +104,16 @@ namespace ILGPU.Algorithms.Tests
         {
             using var stream = Accelerator.CreateStream();
             var size = Math.Max(Accelerator.WarpSize, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
-            input.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
             T expected = CalcValue(sequence, func);
-            T actual = output.GetAsArray()[0];
+            T actual = output.GetAs1DArray()[0];
             Assert.Equal(expected, actual);
         }
 
@@ -137,17 +135,16 @@ namespace ILGPU.Algorithms.Tests
         {
             using var stream = Accelerator.CreateStream();
             var size = Math.Max(Accelerator.WarpSize, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
-            input.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
             
             var expected = Enumerable.Repeat(CalcValue(sequence, func), size).ToArray();
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
 
         [Theory]
@@ -166,17 +163,16 @@ namespace ILGPU.Algorithms.Tests
         {
             using var stream = Accelerator.CreateStream();
             var size = Math.Max(Accelerator.WarpSize, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
-            input.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
             T[] expected = CalcValues(sequence, func, ScanKind.Exclusive);
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
 
         [Theory]
@@ -195,18 +191,17 @@ namespace ILGPU.Algorithms.Tests
             where TSequencer : struct, ITestSequencer<T>
         {
             var size = Math.Max(Accelerator.WarpSize, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
-            input.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
 
             T[] expected = CalcValues(sequence, func, ScanKind.Exclusive);
-            Verify(output, expected, 1);
+            Verify(output.View, expected, 1);
         }
 
         [Theory]
@@ -226,18 +221,17 @@ namespace ILGPU.Algorithms.Tests
             where TSequencer : struct, ITestSequencer<T>
         {
             var size = Math.Max(Accelerator.WarpSize, 1);
-            using var input = Accelerator.Allocate<T>(size);
-            using var output = Accelerator.Allocate<T>(size);
+            using var input = Accelerator.Allocate1D<T>(size);
+            using var output = Accelerator.Allocate1D<T>(size);
             using var stream = Accelerator.CreateStream();
 
             var sequence = sequencer.ComputeSequence(start, stepSize, size);
-            input.CopyFrom(stream, sequence, 0, 0, size);
-            stream.Synchronize();
+            input.CopyFromCPU(stream, sequence);
             
             Execute<KernelConfig, T, TFunction>((1, size), input.View, output.View);
             
             T[] expected = CalcValues(sequence, func, ScanKind.Inclusive);
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
         
         #region Helper Methods

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.BitOperations.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.BitOperations.tt
@@ -13,7 +13,6 @@
 <#@ include file="XMathTests.ttinclude" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System.Numerics;
@@ -44,9 +43,9 @@ namespace ILGPU.Algorithms.Tests
 
 <# foreach (var function in bitFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<int> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<int, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index] << index);
         }
@@ -64,12 +63,12 @@ namespace ILGPU.Algorithms.Tests
                 Enumerable.Range(0, Length)
                 .Select(x => BitOperations.<#= function.Name #>(value << x))
                 .ToArray();
-            using var input = Accelerator.Allocate(
+            using var input = Accelerator.Allocate1D(
                 Enumerable.Repeat(value, Length).ToArray());
-            using var output = Accelerator.Allocate<int>(Length);
+            using var output = Accelerator.Allocate1D<int>(Length);
 
             Execute(input.Length, input.View, output.View);
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Log.tt
@@ -14,7 +14,6 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System;
@@ -53,9 +52,9 @@ namespace ILGPU.Algorithms.Tests
     {
 <# foreach (var function in unaryLogFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -88,12 +87,12 @@ namespace ILGPU.Algorithms.Tests
                 inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -104,19 +103,19 @@ namespace ILGPU.Algorithms.Tests
 #endif
                 .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>
 <# foreach (var function in unaryLog2Functions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -149,12 +148,12 @@ namespace ILGPU.Algorithms.Tests
                 inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -165,19 +164,19 @@ namespace ILGPU.Algorithms.Tests
 #endif
                 .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>
 <# foreach (var function in binaryLogFunctions) { #>
         internal static void Binary<#= function.KernelName #>(
-            Index1 index,
-            ArrayView<XMathTuple<<#= function.DataType #>>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<XMathTuple<<#= function.DataType #>>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index].X, input[index].Y);
         }
@@ -225,12 +224,12 @@ namespace ILGPU.Algorithms.Tests
             }
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<XMathTuple<<#= function.DataType #>>>(
+            using var input = Accelerator.Allocate1D<XMathTuple<<#= function.DataType #>>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -242,11 +241,11 @@ namespace ILGPU.Algorithms.Tests
                 .ToArray();
 
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Pow.tt
@@ -14,7 +14,6 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System;
@@ -51,9 +50,9 @@ namespace ILGPU.Algorithms.Tests
     {
 <# foreach (var function in powFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<XMathTuple<<#= function.DataType #>>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<XMathTuple<<#= function.DataType #>>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index].X, input[index].Y);
         }
@@ -109,12 +108,12 @@ namespace ILGPU.Algorithms.Tests
             }
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<XMathTuple<<#= function.DataType #>>>(
+            using var input = Accelerator.Allocate1D<XMathTuple<<#= function.DataType #>>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -126,17 +125,17 @@ namespace ILGPU.Algorithms.Tests
                 .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.OpenCL #>);
             else
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.CPU #>);
         }
@@ -144,9 +143,9 @@ namespace ILGPU.Algorithms.Tests
 <# } #>
 <# foreach (var function in exp2Functions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -178,12 +177,12 @@ namespace ILGPU.Algorithms.Tests
                 inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -195,17 +194,17 @@ namespace ILGPU.Algorithms.Tests
                     2.0<#= function.ValueSuffix #>, x)).ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.OpenCL #>);
             else
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.CPU #>);
         }
@@ -213,9 +212,9 @@ namespace ILGPU.Algorithms.Tests
 <# } #>
 <# foreach (var function in expFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -247,12 +246,12 @@ namespace ILGPU.Algorithms.Tests
                 inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -264,17 +263,17 @@ namespace ILGPU.Algorithms.Tests
                 .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.OpenCL #>);
             else
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.CPU #>);
         }

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rcp.tt
@@ -13,13 +13,14 @@
 <#@ include file="XMathTests.ttinclude" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+
+// disable: max_line_length
 
 <#
     var rcpFunctions = new []
@@ -36,9 +37,9 @@ namespace ILGPU.Algorithms.Tests
     {
 <# foreach (var function in rcpFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -71,21 +72,21 @@ namespace ILGPU.Algorithms.Tests
                 inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(x => 1 / x).ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Rem.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Rem.tt
@@ -13,7 +13,6 @@
 <#@ include file="XMathTests.ttinclude" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System;
@@ -78,10 +77,10 @@ namespace ILGPU.Algorithms.Tests
             };
 
         internal static void <#= function.KernelName #>(
-            Index1 index,
+            Index1D index,
             <#= function.DataType #> divisor,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index], divisor);
         }
@@ -113,25 +112,25 @@ namespace ILGPU.Algorithms.Tests
 #endif
                 .ToArray();
             using var input =
-                Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
+                Accelerator.Allocate1D<<#= function.DataType #>>(inputArray.Length);
             using var output =
-                Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
+                Accelerator.Allocate1D<<#= function.DataType #>>(inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, divisor, input.View, output.View);
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.OpenCL #>);
             else
                 VerifyWithinRelativeError(
-                    output,
+                    output.View,
                     expected,
                     <#= function.RelativeError.CPU #>);
         }

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Round.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Round.tt
@@ -13,11 +13,12 @@
 <#@ include file="XMathTests.ttinclude" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System;
 using Xunit;
+
+// disable: max_line_length
 
 <#
     var roundFunctions = new []
@@ -164,9 +165,9 @@ namespace ILGPU.Algorithms.Tests
 #if !NETFRAMEWORK // If MidpointRounding mode not supported
 <#      } #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.MethodName #>(input[index]
 <#      if (function.Digits.HasValue) { #>
@@ -203,12 +204,12 @@ namespace ILGPU.Algorithms.Tests
                 #>
 #endif
             };
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(1);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(1);
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(1);
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(1);
 
-            input.CopyFrom(new[] { value }, 0, 0, 1);
+            input.View.CopyFromCPU(ref value, 1L);
             Execute(input.Length, input.View, output.View);
-            Verify(output, expected);
+            Verify(output.View, expected);
         }
 
 <# if (restrictedRoundingMode) { #>

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Sqrt.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Sqrt.tt
@@ -14,7 +14,6 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System;
@@ -45,9 +44,9 @@ namespace ILGPU.Algorithms.Tests
     {
 <# foreach (var function in sqrtFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -79,12 +78,12 @@ namespace ILGPU.Algorithms.Tests
                 inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -95,19 +94,19 @@ namespace ILGPU.Algorithms.Tests
 #endif
                 .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>
 <# foreach (var function in rsqrtFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -139,12 +138,12 @@ namespace ILGPU.Algorithms.Tests
                 inputValues.Add(edgeCases[x]);
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(
                 inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -156,11 +155,11 @@ namespace ILGPU.Algorithms.Tests
 #endif
                     .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
+++ b/Src/ILGPU.Algorithms.Tests/XMathTests.Trig.tt
@@ -14,7 +14,6 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.IO" #>
-<#@ output extension=".cs" #>
 using ILGPU.Runtime;
 using ILGPU.Tests;
 using System;
@@ -63,9 +62,9 @@ namespace ILGPU.Algorithms.Tests
     {
 <# foreach (var function in unaryTrigFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<<#= function.DataType #>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index]);
         }
@@ -97,10 +96,10 @@ namespace ILGPU.Algorithms.Tests
                 }) // Edge cases
                 .ToArray();
 
-            using var input = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
+            using var input = Accelerator.Allocate1D<<#= function.DataType #>>(inputArray.Length);
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -111,19 +110,19 @@ namespace ILGPU.Algorithms.Tests
 #endif
                 .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>
 <# foreach (var function in binaryTrigFunctions) { #>
         internal static void <#= function.KernelName #>(
-            Index1 index,
-            ArrayView<XMathTuple<<#= function.DataType #>>> input,
-            ArrayView<<#= function.DataType #>> output)
+            Index1D index,
+            ArrayView1D<XMathTuple<<#= function.DataType #>>, Stride1D.Dense> input,
+            ArrayView1D<<#= function.DataType #>, Stride1D.Dense> output)
         {
             output[index] = XMath.<#= function.Name #>(input[index].X, input[index].Y);
         }
@@ -171,10 +170,10 @@ namespace ILGPU.Algorithms.Tests
             }
 
             var inputArray = inputValues.ToArray();
-            using var input = Accelerator.Allocate<XMathTuple<<#= function.DataType #>>>(inputArray.Length);
-            using var output = Accelerator.Allocate<<#= function.DataType #>>(inputArray.Length);
+            using var input = Accelerator.Allocate1D<XMathTuple<<#= function.DataType #>>>(inputArray.Length);
+            using var output = Accelerator.Allocate1D<<#= function.DataType #>>(inputArray.Length);
 
-            input.CopyFrom(inputArray, 0, 0, inputArray.Length);
+            input.CopyFromCPU(inputArray);
             Execute(input.Length, input.View, output.View);
 
             var expected = inputArray.Select(
@@ -185,11 +184,11 @@ namespace ILGPU.Algorithms.Tests
 #endif
                     .ToArray();
             if (Accelerator.AcceleratorType == AcceleratorType.Cuda)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.Cuda #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.Cuda #>);
             else if (Accelerator.AcceleratorType == AcceleratorType.OpenCL)
-                VerifyWithinPrecision(output, expected, <#= function.Precision.OpenCL #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.OpenCL #>);
             else
-                VerifyWithinPrecision(output, expected, <#= function.Precision.CPU #>);
+                VerifyWithinPrecision(output.View, expected, <#= function.Precision.CPU #>);
         }
 
 <# } #>

--- a/Src/ILGPU.Algorithms/.editorconfig
+++ b/Src/ILGPU.Algorithms/.editorconfig
@@ -20,3 +20,9 @@ dotnet_code_quality_unused_parameters = all:silent
 
 # CA1060: Move pinvokes to native methods class
 dotnet_diagnostic.CA1060.severity = none
+
+# Default severity for analyzer diagnostics with category 'Security'
+dotnet_analyzer_diagnostic.category-Security.severity = none
+
+# CA5393: Do not use unsafe DllImportSearchPath value
+dotnet_diagnostic.CA5393.severity = none

--- a/Src/ILGPU.Algorithms/AlgorithmContext.cs
+++ b/Src/ILGPU.Algorithms/AlgorithmContext.cs
@@ -14,6 +14,7 @@ using ILGPU.Algorithms;
 using ILGPU.Algorithms.CL;
 using ILGPU.Algorithms.IL;
 using ILGPU.Algorithms.PTX;
+using ILGPU.IR;
 using System;
 using System.Reflection;
 
@@ -64,15 +65,15 @@ namespace ILGPU
         #region Methods
 
         /// <summary>
-        /// Enables algorithm extensions in the scope of the given context.
+        /// Enables algorithm extensions in the scope of the given context builder.
         /// </summary>
-        /// <param name="context">The context to enable algorithms for.</param>
-        public static void EnableAlgorithms(this Context context)
+        /// <param name="builder">The builder to enable algorithms for.</param>
+        public static void EnableAlgorithms(this Context.Builder builder)
         {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
 
-            var intrinsicManager = context.IntrinsicManager;
+            var intrinsicManager = builder.GetIntrinsicManager();
             CLContext.EnableCLAlgorithms(intrinsicManager);
             ILContext.EnableILAlgorithms(intrinsicManager);
             PTXContext.EnablePTXAlgorithms(intrinsicManager);

--- a/Src/ILGPU.Algorithms/ArrayExtensions.cs
+++ b/Src/ILGPU.Algorithms/ArrayExtensions.cs
@@ -26,7 +26,7 @@ namespace ILGPU.Algorithms
         /// <typeparam name="T">The element type.</typeparam>
         /// <param name="array">The source array.</param>
         /// <returns>The extent of an one-dimensional array.</returns>
-        public static Index1 GetExtent<T>(this T[] array)
+        public static Index1D GetExtent<T>(this T[] array)
         {
             Debug.Assert(array != null, "Invalid array");
             return array.Length;
@@ -42,10 +42,10 @@ namespace ILGPU.Algorithms
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional",
             Target = "array")]
-        public static Index2 GetExtent<T>(this T[,] array)
+        public static Index2D GetExtent<T>(this T[,] array)
         {
             Debug.Assert(array != null, "Invalid array");
-            return new Index2(
+            return new Index2D(
                 array.GetLength(0),
                 array.GetLength(1));
         }
@@ -60,10 +60,10 @@ namespace ILGPU.Algorithms
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional",
             Target = "array")]
-        public static Index3 GetExtent<T>(this T[,,] array)
+        public static Index3D GetExtent<T>(this T[,,] array)
         {
             Debug.Assert(array != null, "Invalid array");
-            return new Index3(
+            return new Index3D(
                 array.GetLength(0),
                 array.GetLength(1),
                 array.GetLength(2));
@@ -76,7 +76,7 @@ namespace ILGPU.Algorithms
         /// <param name="array">The source array.</param>
         /// <param name="index">The element index.</param>
         /// <returns>The value at the given index.</returns>
-        public static T GetValue<T>(this T[] array, Index1 index) =>
+        public static T GetValue<T>(this T[] array, Index1D index) =>
             array[index];
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace ILGPU.Algorithms
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional",
             Target = "array")]
-        public static T GetValue<T>(this T[,] array, Index2 index) =>
+        public static T GetValue<T>(this T[,] array, Index2D index) =>
             array[index.X, index.Y];
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace ILGPU.Algorithms
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional",
             Target = "array")]
-        public static T GetValue<T>(this T[,,] array, Index3 index) =>
+        public static T GetValue<T>(this T[,,] array, Index3D index) =>
             array[index.X, index.Y, index.Z];
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace ILGPU.Algorithms
         /// <param name="array">The target array.</param>
         /// <param name="value">The value to set.</param>
         /// <param name="index">The element index.</param>
-        public static void SetValue<T>(this T[] array, T value, Index1 index) =>
+        public static void SetValue<T>(this T[] array, T value, Index1D index) =>
             array[index] = value;
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace ILGPU.Algorithms
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional",
             Target = "array")]
-        public static void SetValue<T>(this T[,] array, T value, Index2 index) =>
+        public static void SetValue<T>(this T[,] array, T value, Index2D index) =>
             array[index.X, index.Y] = value;
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace ILGPU.Algorithms
             "Performance",
             "CA1814:Prefer jagged arrays over multidimensional",
             Target = "array")]
-        public static void SetValue<T>(this T[,,] array, T value, Index3 index) =>
+        public static void SetValue<T>(this T[,,] array, T value, Index3D index) =>
             array[index.X, index.Y, index.Z] = value;
     }
 }

--- a/Src/ILGPU.Algorithms/HistogramLaunchers.tt
+++ b/Src/ILGPU.Algorithms/HistogramLaunchers.tt
@@ -34,12 +34,11 @@ namespace ILGPU.Algorithms
 <# foreach (var type in incrementTypes) { #>
         #region Histogram <#= type.Name #> Launchers
 
-<# for (int i = 1; i <= 3; ++i) { #>
-<#      var dimension = i > 1 ? $"{i}D" : ""; #>
         /// <summary>
-        /// Calculates the histogram (<#= type.Type #>) on the given <#= i #>D view.
+        /// Calculates the histogram (<#= type.Type #>) on the given 1D view.
         /// </summary>
         /// <typeparam name="T">The input view element type.</typeparam>
+        /// <typeparam name="TStride">The input view element type.</typeparam>
         /// <typeparam name="TLocator">
         /// The operation to compute the bin location.
         /// </typeparam>
@@ -53,25 +52,25 @@ namespace ILGPU.Algorithms
 <# if (!type.IsCLSCompliant) { #>
         [CLSCompliant(false)]
 <# } #>
-        public static void Histogram<#= dimension #><T, TLocator>(
+        public static void Histogram<T, TStride, TLocator>(
             this Accelerator accelerator,
             AcceleratorStream stream,
-            ArrayView<#= dimension #><T> view,
+            ArrayView1D<T, TStride> view,
             ArrayView<<#= type.Type #>> histogram,
             ArrayView<int> histogramOverflow)
             where T : unmanaged
-            where TLocator : struct, IComputeSingleBinOperation<T, Index1>
+            where TStride : unmanaged, IStride1D
+            where TLocator : struct, IComputeSingleBinOperation<T, Index1D>
         {
             var kernel = accelerator.CreateHistogram<
                 T,
-                Index<#= i #>,
+                TStride,
                 <#= type.Type #>,
                 HistogramIncrement<#= type.Name #>,
                 ComputeSingleBinAdapter<#= type.Name #><T, TLocator>>();
-            kernel(stream, view.ToIntView(), histogram, histogramOverflow);
+            kernel(stream, view, histogram, histogramOverflow);
         }
 
-<# } #>
         /// <summary>
         /// Adapter to convert single-bin operation into a multi-bin operation for
         /// histograms of type <#= type.Type #>.
@@ -88,7 +87,7 @@ namespace ILGPU.Algorithms
                 <#= type.Type #>,
                 HistogramIncrement<#= type.Name #>>
             where T : unmanaged
-            where TLocator : struct, IComputeSingleBinOperation<T, Index1>
+            where TLocator : struct, IComputeSingleBinOperation<T, Index1D>
         {
             public void ComputeHistogramBins(
                 T value,

--- a/Src/ILGPU.Algorithms/IL/ILFunctions.cs
+++ b/Src/ILGPU.Algorithms/IL/ILFunctions.cs
@@ -1,0 +1,194 @@
+﻿// ---------------------------------------------------------------------------------------
+//                                   ILGPU.Algorithms
+//                      Copyright (c) 2019 ILGPU Algorithms Project
+//                                    www.ilgpu.net
+//
+// File: ILFunctions.cs
+//
+// This file is part of ILGPU and is distributed under the University of Illinois Open
+// Source License. See LICENSE.txt for details
+// ---------------------------------------------------------------------------------------
+
+using ILGPU.Algorithms.ScanReduceOperations;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace ILGPU.Algorithms.IL
+{
+    /// <summary>
+    /// Custom IL-specific implementations.
+    /// </summary>
+    static class ILFunctions
+    {
+        #region Nested Types
+
+        public interface IILFunctionImplementation
+        {
+            /// <summary>
+            /// The maximum number of supported thread per context on the CPU accelerator
+            /// for the implementation of specific algorithms.
+            /// </summary>
+            int MaxNumThreads { get; }
+
+            /// <summary>
+            /// Returns true if the current thread is the first thread.
+            /// </summary>
+            bool IsFirstThread { get; }
+
+            /// <summary>
+            /// Returns the current linear thread index.
+            /// </summary>
+            int ThreadIndex { get; }
+
+            /// <summary>
+            /// Returns the linear thread dimension.
+            /// </summary>
+            int ThreadDimension { get; }
+
+            /// <summary>
+            /// Executes a barrier in the current context.
+            /// </summary>
+            void Barrier();
+        }
+
+        #endregion
+
+        #region Reduce
+
+        /// <summary cref="GroupExtensions.Reduce{T, TReduction}(T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Reduce<T, TReduction, TImpl>(T value)
+            where T : unmanaged
+            where TReduction : IScanReduceOperation<T>
+            where TImpl : struct, IILFunctionImplementation =>
+            AllReduce<T, TReduction, TImpl>(value);
+
+        /// <summary cref="GroupExtensions.AllReduce{T, TReduction}(T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T AllReduce<T, TReduction, TImpl>(T value)
+            where T : unmanaged
+            where TReduction : IScanReduceOperation<T>
+            where TImpl : struct, IILFunctionImplementation
+        {
+            ref var sharedMemory = ref SharedMemory.Allocate<T>();
+
+            TReduction reduction = default;
+            TImpl impl = default;
+            if (impl.IsFirstThread)
+                sharedMemory = reduction.Identity;
+            impl.Barrier();
+
+            reduction.AtomicApply(ref sharedMemory, value);
+
+            impl.Barrier();
+            return sharedMemory;
+        }
+
+        #endregion
+
+        #region Scan
+
+        /// <summary cref="GroupExtensions.ExclusiveScan{T, TScanOperation}(T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ExclusiveScan<T, TScanOperation, TImpl>(T value)
+            where T : unmanaged
+            where TScanOperation : struct, IScanReduceOperation<T>
+            where TImpl : struct, IILFunctionImplementation =>
+            ExclusiveScanWithBoundaries<T, TScanOperation, TImpl>(value, out var _);
+
+        /// <summary cref="GroupExtensions.InclusiveScan{T, TScanOperation}(T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T InclusiveScan<T, TScanOperation, TImpl>(T value)
+            where T : unmanaged
+            where TScanOperation : struct, IScanReduceOperation<T>
+            where TImpl : struct, IILFunctionImplementation =>
+            InclusiveScanWithBoundaries<T, TScanOperation, TImpl>(value, out var _);
+
+        /// <summary cref="GroupExtensions.ExclusiveScanWithBoundaries{T, TScanOperation}(
+        /// T, out ScanBoundaries{T})"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ExclusiveScanWithBoundaries<T, TScanOperation, TImpl>(
+            T value,
+            out ScanBoundaries<T> boundaries)
+            where T : unmanaged
+            where TScanOperation : struct, IScanReduceOperation<T>
+            where TImpl : struct, IILFunctionImplementation
+        {
+            TImpl impl = default;
+            var sharedMemory = InclusiveScanImplementation<T, TScanOperation, TImpl>(
+                value);
+            boundaries = new ScanBoundaries<T>(
+                sharedMemory[0],
+                sharedMemory[Math.Max(0, impl.ThreadDimension - 2)]);
+            return impl.IsFirstThread
+                ? default(TScanOperation).Identity
+                : sharedMemory[impl.ThreadIndex - 1];
+        }
+
+        /// <summary cref="GroupExtensions.InclusiveScanWithBoundaries{T, TScanOperation}(
+        /// T, out ScanBoundaries{T})"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T InclusiveScanWithBoundaries<T, TScanOperation, TImpl>(
+            T value,
+            out ScanBoundaries<T> boundaries)
+            where T : unmanaged
+            where TScanOperation : struct, IScanReduceOperation<T>
+            where TImpl : struct, IILFunctionImplementation
+        {
+            TImpl impl = default;
+            var sharedMemory = InclusiveScanImplementation<T, TScanOperation, TImpl>(
+                value);
+            boundaries = new ScanBoundaries<T>(
+                sharedMemory[0],
+                sharedMemory[impl.ThreadDimension - 1]);
+            return sharedMemory[impl.ThreadIndex];
+        }
+
+        /// <summary>
+        /// Performs a group-wide inclusive scan.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TScanOperation">The type of the warp scan logic.</typeparam>
+        /// <typeparam name="TImpl">The internal implementation type.</typeparam>
+        /// <param name="value">The value to scan.</param>
+        /// <returns>The resulting value for the current lane.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ArrayView<T> InclusiveScanImplementation<
+            T,
+            TScanOperation,
+            TImpl>(
+            T value)
+            where T : unmanaged
+            where TScanOperation : struct, IScanReduceOperation<T>
+            where TImpl : struct, IILFunctionImplementation
+        {
+            TImpl impl = default;
+
+            // Load values into shared memory
+            var sharedMemory = SharedMemory.Allocate<T>(impl.MaxNumThreads);
+            Debug.Assert(
+                impl.ThreadDimension <= impl.MaxNumThreads,
+                "Invalid group/warp size");
+            sharedMemory[impl.ThreadIndex] = value;
+            impl.Barrier();
+
+            // First thread performs all operations
+            if (impl.IsFirstThread)
+            {
+                TScanOperation scanOperation = default;
+                for (int i = 1; i < impl.ThreadDimension; ++i)
+                {
+                    sharedMemory[i] = scanOperation.Apply(
+                        sharedMemory[i - 1],
+                        sharedMemory[i]);
+                }
+            }
+            impl.Barrier();
+
+            return sharedMemory;
+        }
+
+        #endregion
+    }
+}

--- a/Src/ILGPU.Algorithms/IL/ILWarpExtensions.cs
+++ b/Src/ILGPU.Algorithms/IL/ILWarpExtensions.cs
@@ -11,6 +11,7 @@
 
 using ILGPU.Algorithms.ScanReduceOperations;
 using System.Runtime.CompilerServices;
+using static ILGPU.Algorithms.IL.ILFunctions;
 
 namespace ILGPU.Algorithms.IL
 {
@@ -19,19 +20,59 @@ namespace ILGPU.Algorithms.IL
     /// </summary>
     static class ILWarpExtensions
     {
+        #region Nested Types
+
+        /// <summary>
+        /// Implements ILFunctions for warps.
+        /// </summary>
+        private readonly struct WarpImplementation : IILFunctionImplementation
+        {
+            /// <summary>
+            /// Returns 256.
+            /// </summary>
+            /// <remarks>
+            /// TODO: refine the implementation to avoid a hard-coded constant.
+            /// </remarks>
+            public readonly int MaxNumThreads => 256;
+
+            /// <summary>
+            /// Returns true if this is the first warp thread.
+            /// </summary>
+            public readonly bool IsFirstThread => Warp.IsFirstLane;
+
+            /// <summary>
+            /// Returns current lane index.
+            /// </summary>
+            public readonly int ThreadIndex => Warp.LaneIdx;
+
+            /// <summary>
+            /// Returns the warp size.
+            /// </summary>
+            public readonly int ThreadDimension => Warp.WarpSize;
+
+            /// <summary>
+            /// Performs a warp-wide barrier.
+            /// </summary>
+            public readonly void Barrier() => Warp.Barrier();
+        }
+
+        #endregion
+
         #region Reduce
 
-        /// <summary cref="WarpExtensions.Reduce{T, TReduction}"/>
+        /// <summary cref="WarpExtensions.Reduce{T, TReduction}(T)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Reduce<T, TReduction>(T value)
-            where T : struct
-            where TReduction : IScanReduceOperation<T> => value;
+            where T : unmanaged
+            where TReduction : IScanReduceOperation<T> =>
+            AllReduce<T, TReduction>(value);
 
         /// <summary cref="WarpExtensions.AllReduce{T, TReduction}(T)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T AllReduce<T, TReduction>(T value)
-            where T : struct
-            where TReduction : IScanReduceOperation<T> => value;
+            where T : unmanaged
+            where TReduction : IScanReduceOperation<T> =>
+            AllReduce<T, TReduction, WarpImplementation>(value);
 
         #endregion
 
@@ -40,14 +81,16 @@ namespace ILGPU.Algorithms.IL
         /// <summary cref="WarpExtensions.ExclusiveScan{T, TScanOperation}(T)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T ExclusiveScan<T, TScanOperation>(T value)
-            where T : struct
-            where TScanOperation : struct, IScanReduceOperation<T> => default;
+            where T : unmanaged
+            where TScanOperation : struct, IScanReduceOperation<T> =>
+            ExclusiveScan<T, TScanOperation, WarpImplementation>(value);
 
         /// <summary cref="WarpExtensions.InclusiveScan{T, TScanOperation}(T)"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T InclusiveScan<T, TScanOperation>(T value)
-            where T : struct
-            where TScanOperation : struct, IScanReduceOperation<T> => value;
+            where T : unmanaged
+            where TScanOperation : struct, IScanReduceOperation<T> =>
+            InclusiveScan<T, TScanOperation, WarpImplementation>(value);
 
         #endregion
     }

--- a/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
+++ b/Src/ILGPU.Algorithms/ILGPU.Algorithms.csproj
@@ -65,6 +65,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="T4.Build" Version="0.2.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\ILGPU\Src\ILGPU\ILGPU.csproj" />
   </ItemGroup>
 
@@ -283,5 +287,4 @@
   </ItemGroup>
 
   <Import Project="Properties\ILGPU.Algorithms.nuspec.targets" />
-  <Import Project="..\..\ILGPU\Src\TextTransform.targets" />
 </Project>

--- a/Src/ILGPU.Algorithms/InitializeExtensions.cs
+++ b/Src/ILGPU.Algorithms/InitializeExtensions.cs
@@ -10,9 +10,9 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Algorithms.Resources;
 using ILGPU.Runtime;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace ILGPU.Algorithms
 {
@@ -20,14 +20,16 @@ namespace ILGPU.Algorithms
     /// Performs an initialization on the given view.
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="view">The element view.</param>
     /// <param name="value">The target value.</param>
-    public delegate void Initializer<T>(
+    public delegate void Initializer<T, TStride>(
         AcceleratorStream stream,
-        ArrayView<T> view,
+        ArrayView1D<T, TStride> view,
         T value)
-        where T : unmanaged;
+        where T : unmanaged
+        where TStride : struct, IStride1D;
 
     /// <summary>
     /// Initialize functionality for accelerators.
@@ -37,64 +39,100 @@ namespace ILGPU.Algorithms
         #region Initialize Implementation
 
         /// <summary>
-        /// The actual initialize implementation.
+        /// A actual raw initializer implementation.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
-        /// <param name="index">The current thread index.</param>
-        /// <param name="view">The target view.</param>
-        /// <param name="value">The value.</param>
-        internal static void InitializeKernel<T>(Index1 index, ArrayView<T> view, T value)
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
+        internal readonly struct InitializerImplementation<T, TStride> :
+            IGridStrideKernelBody
             where T : unmanaged
+            where TStride : struct, IStride1D
         {
-            var stride = GridExtensions.GridStrideLoopStride;
-            for (var idx = index; idx < view.Length; idx += stride)
-                view[idx] = value;
+            /// <summary>
+            /// Creates a new initializer implementation.
+            /// </summary>
+            /// <param name="view">The parent target view.</param>
+            /// <param name="value">The initializer value.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public InitializerImplementation(ArrayView1D<T, TStride> view, T value)
+            {
+                View = view;
+                Value = value;
+            }
+
+            /// <summary>
+            /// Returns the target view.
+            /// </summary>
+            public ArrayView1D<T, TStride> View { get; }
+
+            /// <summary>
+            /// Returns the initializer value.
+            /// </summary>
+            public T Value { get; }
+
+            /// <summary>
+            /// Executes this sequencer wrapper.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Execute(LongIndex1D linearIndex)
+            {
+                if (linearIndex >= View.Length)
+                    return;
+
+                View[linearIndex] = Value;
+            }
+
+            /// <summary>
+            /// Performs no operation.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Finish() { }
         }
 
         /// <summary>
         /// Creates a raw initializer that is defined by the given element type.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
-        /// <param name="minDataSize">The minimum data size for maximum occupancy.</param>
         /// <returns>The loaded initializer.</returns>
-        private static Action<AcceleratorStream, Index1, ArrayView<T>, T>
-            CreateRawInitializer<T>(
-            this Accelerator accelerator,
-            out Index1 minDataSize)
+        private static Action<
+            AcceleratorStream,
+            LongIndex1D,
+            InitializerImplementation<T, TStride>>
+            CreateRawInitializer<T, TStride>(
+            this Accelerator accelerator)
             where T : unmanaged
-        {
-            var result = accelerator.LoadAutoGroupedKernel(
-                (Action<Index1, ArrayView<T>, T>)InitializeKernel,
-                out var info);
-            minDataSize = info.MinGroupSize.Value * info.MinGridSize.Value;
-            return result;
-        }
+            where TStride : struct, IStride1D =>
+            accelerator.LoadGridStrideKernel<
+                InitializerImplementation<T, TStride>>();
 
         /// <summary>
         /// Creates an initializer that is defined by the given element type.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <returns>The loaded transformer.</returns>
-        public static Initializer<T> CreateInitializer<T>(
+        public static Initializer<T, TStride> CreateInitializer<T, TStride>(
             this Accelerator accelerator)
             where T : unmanaged
+            where TStride : struct, IStride1D
         {
-            var rawInitializer = accelerator.CreateRawInitializer<T>(
-                out Index1 minDataSize);
+            var rawInitializer = accelerator.CreateRawInitializer<T, TStride>();
             return (stream, view, value) =>
             {
                 if (!view.IsValid)
                     throw new ArgumentNullException(nameof(view));
                 if (view.Length < 1)
                     throw new ArgumentOutOfRangeException(nameof(view));
-                if (view.Length > int.MaxValue)
-                {
-                    throw new NotSupportedException(
-                        ErrorMessages.NotSupportedArrayView64);
-                }
-                rawInitializer(stream, Math.Min(view.Length, minDataSize), view, value);
+
+                rawInitializer(
+                    stream,
+                    view.Length,
+                    new InitializerImplementation<T, TStride>(
+                        view,
+                        value));
             };
         }
 
@@ -111,13 +149,32 @@ namespace ILGPU.Algorithms
             AcceleratorStream stream,
             ArrayView<T> view,
             T value)
-            where T : unmanaged
-        {
-            accelerator.CreateInitializer<T>()(
+            where T : unmanaged =>
+            accelerator.CreateInitializer<T, Stride1D.Dense>()(
                 stream,
                 view,
                 value);
-        }
+
+        /// <summary>
+        /// Performs an initialization on the given view.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The element view.</param>
+        /// <param name="value">The target value.</param>
+        public static void Initialize<T, TStride>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> view,
+            T value)
+            where T : unmanaged
+            where TStride : struct, IStride1D =>
+            accelerator.CreateInitializer<T, TStride>()(
+                stream,
+                view,
+                value);
 
         #endregion
     }

--- a/Src/ILGPU.Algorithms/PTX/PTXContext.Generated.tt
+++ b/Src/ILGPU.Algorithms/PTX/PTXContext.Generated.tt
@@ -59,9 +59,9 @@ var xmathBinaryRedirects = new[]
         "IEEERemainder",
     };
 #>
-using ILGPU.Backends;
 using ILGPU.IR.Intrinsics;
 using ILGPU.IR.Values;
+using ILGPU.Runtime.Cuda;
 
 namespace ILGPU.Algorithms.PTX
 {
@@ -108,7 +108,7 @@ namespace ILGPU.Algorithms.PTX
             manager.RegisterUnaryArithmetic(
                 UnaryArithmeticKind.<#= kind #>,
                 BasicValueType.<#= basicType #>,
-                GetMathCodeGeneratorIntrinsic(PTXArchitecture.<#= sm #>));
+                GetMathCodeGeneratorIntrinsic(CudaArchitecture.<#= sm #>));
 <#      } #>
 <# } #>
 

--- a/Src/ILGPU.Algorithms/PTX/PTXContext.cs
+++ b/Src/ILGPU.Algorithms/PTX/PTXContext.cs
@@ -9,9 +9,9 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Backends;
 using ILGPU.Backends.PTX;
 using ILGPU.IR.Intrinsics;
+using ILGPU.Runtime.Cuda;
 using System;
 using System.Reflection;
 
@@ -62,7 +62,7 @@ namespace ILGPU.Algorithms.PTX
         /// <param name="minArchitecture">The target/minimum architecture.</param>
         /// <returns>The resolved intrinsic representation.</returns>
         private static PTXIntrinsic GetMathCodeGeneratorIntrinsic(
-            PTXArchitecture minArchitecture) =>
+            CudaArchitecture minArchitecture) =>
             new PTXIntrinsic(
                 PTXMathType,
                 nameof(PTXMath.GenerateMathIntrinsic),

--- a/Src/ILGPU.Algorithms/Random/RNG.cs
+++ b/Src/ILGPU.Algorithms/Random/RNG.cs
@@ -188,7 +188,6 @@ namespace ILGPU.Algorithms.Random
             return ref randomProviders[warpIdx];
         }
 
-
         /// <summary>
         /// Generates a random value using the operation provided.
         /// </summary>
@@ -203,6 +202,7 @@ namespace ILGPU.Algorithms.Random
             // Load provider from memory
             ref var providerRef = ref GetRandomProvider();
             var provider = providerRef;
+            Warp.Barrier();
 
             // Shift the local period
             provider.ShiftPeriod(Warp.LaneIdx);
@@ -214,6 +214,7 @@ namespace ILGPU.Algorithms.Random
             // Store the updated provider in the first warp
             if (Warp.IsFirstLane)
                 providerRef = provider;
+            Warp.Barrier();
 
             return result;
         }

--- a/Src/ILGPU.Algorithms/ReductionExtensions.cs
+++ b/Src/ILGPU.Algorithms/ReductionExtensions.cs
@@ -10,10 +10,10 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Algorithms.Resources;
 using ILGPU.Algorithms.ScanReduceOperations;
 using ILGPU.Runtime;
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace ILGPU.Algorithms
@@ -24,14 +24,16 @@ namespace ILGPU.Algorithms
     /// Represents a reduction using a reduction logic.
     /// </summary>
     /// <typeparam name="T">The underlying type of the reduction.</typeparam>
+    /// <typeparam name="TStride">The 1D stride of the source view.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="input">The input elements to reduce.</param>
     /// <param name="output">The output view to store the reduced value.</param>
-    public delegate void Reduction<T>(
+    public delegate void Reduction<T, TStride>(
         AcceleratorStream stream,
-        ArrayView<T> input,
+        ArrayView1D<T, TStride> input,
         ArrayView<T> output)
-        where T : unmanaged;
+        where T : unmanaged
+        where TStride : struct, IStride1D;
 
     #endregion
 
@@ -43,13 +45,94 @@ namespace ILGPU.Algorithms
         #region Reduction Implementation
 
         /// <summary>
+        /// A actual raw reduction implementation.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the source view.</typeparam>
+        /// <typeparam name="TReduction">The type of the reduction to use.</typeparam>
+        internal struct ReductionImplementation<
+            T,
+            TStride,
+            TReduction> : IGridStrideKernelBody
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TReduction : struct, IScanReduceOperation<T>
+        {
+            /// <summary>
+            /// Creates a new reduction instance.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static TReduction GetReduction()
+            {
+                TReduction reduction = default;
+                return reduction;
+            }
+
+            /// <summary>
+            /// Creates a new reduction implementation.
+            /// </summary>
+            /// <param name="input">The input view.</param>
+            /// <param name="output">The output view (1 element min).</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public ReductionImplementation(
+                ArrayView1D<T, TStride> input,
+                ArrayView<T> output)
+            {
+                Input = input;
+                Output = output;
+                ReducedValue = GetReduction().Identity;
+            }
+
+            /// <summary>
+            /// Returns the source view.
+            /// </summary>
+            public ArrayView1D<T, TStride> Input { get; }
+
+            /// <summary>
+            /// Returns the output view.
+            /// </summary>
+            public ArrayView<T> Output { get; }
+
+            /// <summary>
+            /// Stores the current intermediate result of this thread.
+            /// </summary>
+            public T ReducedValue { get; private set; }
+
+            /// <summary>
+            /// Reduces each element in a grid-stride loop.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Execute(LongIndex1D linearIndex)
+            {
+                if (linearIndex >= Input.Length)
+                    return;
+
+                ReducedValue = GetReduction().Apply(ReducedValue, Input[linearIndex]);
+            }
+
+            /// <summary>
+            /// Finished a group-wide reduction operation using shuffles, shared memory
+            /// and atomic operations.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Finish()
+            {
+                // Perform group wide reduction
+                ReducedValue = GroupExtensions.Reduce<T, TReduction>(ReducedValue);
+
+                if (Group.IsFirstThread)
+                    GetReduction().AtomicApply(ref Output[0], ReducedValue);
+            }
+        }
+
+        /// <summary>
         /// Computes a group size for reduction-kernel dispatch.
         /// </summary>
         /// <param name="accelerator">The accelerator.</param>
         /// <returns>
         /// The grouped reduction dimension for reduction-kernel dispatch.
         /// </returns>
-        private static Index1 ComputeReductionGroupSize(Accelerator accelerator)
+        private static Index1D ComputeReductionGroupSize(Accelerator accelerator)
         {
             var warpSize = accelerator.WarpSize;
             return Math.Max(
@@ -58,64 +141,22 @@ namespace ILGPU.Algorithms
         }
 
         /// <summary>
-        /// Computes a grouped reduction dimension for reduction-kernel dispatch.
-        /// </summary>
-        /// <param name="accelerator">The accelerator.</param>
-        /// <param name="dataLength">The number of data elements to reduce.</param>
-        /// <returns>
-        /// The grouped reduction dimension for reduction-kernel dispatch.
-        /// </returns>
-        private static (Index1, Index1) ComputeReductionDimension(
-            Accelerator accelerator,
-            Index1 dataLength)
-        {
-            var groupDim = ComputeReductionGroupSize(accelerator);
-            var gridDim = Math.Min((dataLength + groupDim - 1) / groupDim, groupDim);
-            return (gridDim, groupDim);
-        }
-
-        /// <summary>
-        /// The actual reduction implementation.
-        /// </summary>
-        /// <typeparam name="T">The underlying type of the reduction.</typeparam>
-        /// <typeparam name="TReduction">The type of the reduction logic.</typeparam>
-        /// <param name="input">The input view.</param>
-        /// <param name="output">The output view.</param>
-        internal static void ReductionKernel<T, TReduction>(
-            ArrayView<T> input,
-            ArrayView<T> output)
-            where T : unmanaged
-            where TReduction : struct, IScanReduceOperation<T>
-        {
-            var stride = GridExtensions.GridStrideLoopStride;
-
-            TReduction reduction = default;
-
-            var reduced = reduction.Identity;
-            for (var idx = Grid.GlobalIndex.X; idx < input.Length; idx += stride)
-                reduced = reduction.Apply(reduced, input[idx]);
-
-            reduced = GroupExtensions.Reduce<T, TReduction>(reduced);
-
-            if (Group.IsFirstThread)
-                reduction.AtomicApply(ref output[0], reduced);
-        }
-
-        /// <summary>
         /// Creates a new instance of a reduction handler.
         /// </summary>
         /// <typeparam name="T">The underlying type of the reduction.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the source view.</typeparam>
         /// <typeparam name="TReduction">The type of the reduction logic.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <returns>The created reduction handler.</returns>
-        public static Reduction<T> CreateReduction<T, TReduction>(
+        public static Reduction<T, TStride> CreateReduction<T, TStride, TReduction>(
             this Accelerator accelerator)
             where T : unmanaged
+            where TStride : struct, IStride1D
             where TReduction : struct, IScanReduceOperation<T>
         {
-            var initializer = accelerator.CreateInitializer<T>();
-            var kernel = accelerator.LoadKernel<ArrayView<T>, ArrayView<T>>(
-                ReductionKernel<T, TReduction>);
+            var initializer = accelerator.CreateInitializer<T, Stride1D.Dense>();
+            var reductionKernel = accelerator.LoadGridStrideKernel<
+                ReductionImplementation<T, TStride, TReduction>>();
             return (stream, input, output) =>
             {
                 if (!input.IsValid)
@@ -126,17 +167,18 @@ namespace ILGPU.Algorithms
                     throw new ArgumentNullException(nameof(output));
                 if (output.Length < 1)
                     throw new ArgumentOutOfRangeException(nameof(output));
-                if (input.Length > int.MaxValue)
-                {
-                    throw new NotSupportedException(
-                        ErrorMessages.NotSupportedArrayView64);
-                }
-                var dimension = ComputeReductionDimension(accelerator, input.Length);
+
+                // Ensure a single element in the ouput view
+                output = output.SubView(0, 1);
 
                 TReduction reduction = default;
                 initializer(stream, output, reduction.Identity);
-
-                kernel(stream, dimension, input, output);
+                reductionKernel(
+                    stream,
+                    input.Length,
+                    new ReductionImplementation<T, TStride, TReduction>(
+                        input,
+                        output));
             };
         }
 
@@ -157,13 +199,11 @@ namespace ILGPU.Algorithms
             ArrayView<T> input,
             ArrayView<T> output)
             where T : unmanaged
-            where TReduction : struct, IScanReduceOperation<T>
-        {
-            accelerator.CreateReduction<T, TReduction>()(
+            where TReduction : struct, IScanReduceOperation<T> =>
+            accelerator.CreateReduction<T, Stride1D.Dense, TReduction>()(
                 stream,
                 input,
                 output);
-        }
 
         /// <summary>
         /// Performs a reduction using a reduction logic.
@@ -186,8 +226,7 @@ namespace ILGPU.Algorithms
         {
             var output = accelerator.MemoryCache.Allocate<T>(1);
             accelerator.Reduce<T, TReduction>(stream, input, output);
-            stream.Synchronize();
-            accelerator.MemoryCache.CopyTo(stream, out T result, 0);
+            output.CopyToCPU(stream, out T result, 1);
             return result;
         }
 
@@ -208,10 +247,79 @@ namespace ILGPU.Algorithms
             AcceleratorStream stream,
             ArrayView<T> input)
             where T : unmanaged
+            where TReduction : struct, IScanReduceOperation<T> =>
+            Task.Run(() => accelerator.Reduce<T, TReduction>(stream, input));
+
+        /// <summary>
+        /// Performs a reduction using a reduction logic.
+        /// </summary>
+        /// <typeparam name="T">The underlying type of the reduction.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the input view.</typeparam>
+        /// <typeparam name="TReduction">The type of the reduction logic.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="input">The input elements to reduce.</param>
+        /// <param name="output">The output view to store the reduced value.</param>
+        public static void Reduce<T, TStride, TReduction>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> input,
+            ArrayView<T> output)
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TReduction : struct, IScanReduceOperation<T> =>
+            accelerator.CreateReduction<T, TStride, TReduction>()(
+                stream,
+                input,
+                output);
+
+        /// <summary>
+        /// Performs a reduction using a reduction logic.
+        /// </summary>
+        /// <typeparam name="T">The underlying type of the reduction.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the input view.</typeparam>
+        /// <typeparam name="TReduction">The type of the reduction logic.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="input">The input elements to reduce.</param>
+        /// <remarks>
+        /// Uses the internal cache to realize a temporary output buffer.
+        /// </remarks>
+        /// <returns>The reduced value.</returns>
+        public static T Reduce<T, TStride, TReduction>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> input)
+            where T : unmanaged
+            where TStride : struct, IStride1D
             where TReduction : struct, IScanReduceOperation<T>
         {
-            return Task.Run(() =>
-                accelerator.Reduce<T, TReduction>(stream, input));
+            var output = accelerator.MemoryCache.Allocate<T>(1);
+            accelerator.Reduce<T, TStride, TReduction>(stream, input, output);
+            output.CopyToCPU(stream, out T result, 1);
+            return result;
         }
+
+        /// <summary>
+        /// Performs a reduction using a reduction logic.
+        /// </summary>
+        /// <typeparam name="T">The underlying type of the reduction.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the input view.</typeparam>
+        /// <typeparam name="TReduction">The type of the reduction logic.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="input">The input elements to reduce.</param>
+        /// <remarks>
+        /// Uses the internal cache to realize a temporary output buffer.
+        /// </remarks>
+        /// <returns>The reduced value.</returns>
+        public static Task<T> ReduceAsync<T, TStride, TReduction>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> input)
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TReduction : struct, IScanReduceOperation<T> =>
+            Task.Run(() => accelerator.Reduce<T, TStride, TReduction>(stream, input));
     }
 }

--- a/Src/ILGPU.Algorithms/ReorderExtensions.cs
+++ b/Src/ILGPU.Algorithms/ReorderExtensions.cs
@@ -44,7 +44,7 @@ namespace ILGPU.Algorithms
         AcceleratorStream stream,
         ArrayView<TSource> source,
         ArrayView<TTarget> target,
-        ArrayView<Index1> reorderView,
+        ArrayView<Index1D> reorderView,
         TTransformer transformer)
         where TSource : unmanaged
         where TTarget : unmanaged
@@ -74,7 +74,7 @@ namespace ILGPU.Algorithms
         /// </typeparam>
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         internal readonly struct ReorderTransformWrapper<TSource, TTarget, TTransformer> :
-            ITransformer<Index1, TTarget>
+            ITransformer<Index1D, TTarget>
             where TSource : unmanaged
             where TTarget : unmanaged
             where TTransformer : struct, ITransformer<TSource, TTarget>
@@ -113,7 +113,7 @@ namespace ILGPU.Algorithms
             #region ITransformer
 
             /// <summary cref="ITransformer{TSource, TTarget}.Transform(TSource)"/>
-            public readonly TTarget Transform(Index1 value)
+            public readonly TTarget Transform(Index1D value)
             {
                 var sourceValue = SourceView[value];
                 return Transformer.Transform(sourceValue);
@@ -152,7 +152,7 @@ namespace ILGPU.Algorithms
             where TTransformer : struct, ITransformer<TSource, TTarget>
         {
             var baseTransformer = accelerator.CreateTransformer<
-                Index1,
+                Index1D,
                 TTarget,
                 ReorderTransformWrapper<TSource, TTarget, TTransformer>>();
             return (stream, source, target, reorderView, transformer) =>
@@ -197,7 +197,7 @@ namespace ILGPU.Algorithms
             AcceleratorStream stream,
             ArrayView<T> source,
             ArrayView<T> target,
-            ArrayView<Index1> reorderView)
+            ArrayView<Index1D> reorderView)
             where T : unmanaged
         {
             accelerator.ReorderTransform<T, IdentityTransformer<T>>(
@@ -235,7 +235,7 @@ namespace ILGPU.Algorithms
             AcceleratorStream stream,
             ArrayView<T> source,
             ArrayView<T> target,
-            ArrayView<Index1> reorderView,
+            ArrayView<Index1D> reorderView,
             TTransformer transformer)
             where T : unmanaged
             where TTransformer : struct, ITransformer<T, T>
@@ -278,7 +278,7 @@ namespace ILGPU.Algorithms
             AcceleratorStream stream,
             ArrayView<TSource> source,
             ArrayView<TTarget> target,
-            ArrayView<Index1> reorderView,
+            ArrayView<Index1D> reorderView,
             TTransformer transformer)
             where TSource : unmanaged
             where TTarget : unmanaged

--- a/Src/ILGPU.Algorithms/Resources/ErrorMessages.Designer.cs
+++ b/Src/ILGPU.Algorithms/Resources/ErrorMessages.Designer.cs
@@ -86,5 +86,14 @@ namespace ILGPU.Algorithms.Resources {
                 return ResourceManager.GetString("TempViewManagerUnalignedAllocation", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The {0} view is larger than the {1} view..
+        /// </summary>
+        internal static string ViewOutOfRange {
+            get {
+                return ResourceManager.GetString("ViewOutOfRange", resourceCulture);
+            }
+        }
     }
 }

--- a/Src/ILGPU.Algorithms/Resources/ErrorMessages.resx
+++ b/Src/ILGPU.Algorithms/Resources/ErrorMessages.resx
@@ -126,4 +126,7 @@
   <data name="TempViewManagerUnalignedAllocation" xml:space="preserve">
     <value>The allocation of type '{0}' is not correctly aligned. Requires '{1}' byte alignment but was allocated at byte offset '{2}'.</value>
   </data>
+  <data name="ViewOutOfRange" xml:space="preserve">
+    <value>The {0} view is larger than the {1} view.</value>
+  </data>
 </root>

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuBlasAPI.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuBlasAPI.cs
@@ -10,7 +10,6 @@
 // ---------------------------------------------------------------------------------------
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace ILGPU.Runtime.Cuda.API
 {
@@ -51,23 +50,23 @@ namespace ILGPU.Runtime.Cuda.API
             {
                 var version = (CuBlasAPIVersion)versions.GetValue(i);
                 var api = CreateInternal(version);
-                if (api != null)
+                if (api is null)
+                    continue;
+
+                try
                 {
-                    try
+                    var status = api.Create(out var handle);
+                    if (status == CuBlasStatus.CUBLAS_STATUS_SUCCESS)
                     {
-                        var status = api.Create(out var handle);
-                        if (status == CuBlasStatus.CUBLAS_STATUS_SUCCESS)
-                        {
-                            api.Free(handle);
-                            return api;
-                        }
+                        api.Free(handle);
+                        return api;
                     }
-                    catch (Exception ex) when (
-                        ex is DllNotFoundException ||
-                        ex is EntryPointNotFoundException)
-                    {
-                        firstException ??= ex;
-                    }
+                }
+                catch (Exception ex) when (
+                    ex is DllNotFoundException ||
+                    ex is EntryPointNotFoundException)
+                {
+                    firstException ??= ex;
                 }
             }
 

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuBlasNativeMethods.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuBlasNativeMethods.tt
@@ -78,52 +78,63 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      if (define) { #>
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasCreate_v2(out IntPtr handle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasGetVersion_v2(
             IntPtr handle,
             out int version);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasDestroy_v2(IntPtr handle);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasGetStream_v2(
             IntPtr handle,
             out IntPtr stream);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasSetStream_v2(
             IntPtr handle,
             IntPtr stream);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasGetPointerMode_v2(
             IntPtr handle,
             out CuBlasPointerMode mode);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasSetPointerMode_v2(
             IntPtr handle,
             CuBlasPointerMode mode);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasGetAtomicsMode(
             IntPtr handle,
             out CuBlasAtomicsMode mode);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasSetAtomicsMode(
             IntPtr handle,
             CuBlasAtomicsMode mode);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasGetMathMode(
             IntPtr handle,
             out CuBlasMathMode mode);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus cublasSetMathMode(
             IntPtr handle,
@@ -182,6 +193,7 @@ namespace ILGPU.Runtime.Cuda.API
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Amax, Amin, Asum, Nrm2)) { #>
 <#          if (define) { #>
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -213,6 +225,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Axpy)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -249,6 +262,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Dot, RotM)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -279,6 +293,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Rot)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -312,6 +327,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(RotG)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -342,6 +358,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Scal)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -372,6 +389,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Swap)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -403,6 +421,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Gbmv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -453,6 +472,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Gemv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -499,6 +519,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Ger)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -538,6 +559,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Sbmv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -584,6 +606,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Spmv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -630,6 +653,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Spr)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -668,6 +692,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Spr2)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -710,6 +735,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Symv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -756,6 +782,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Syr)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -794,6 +821,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Syr2)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -836,6 +864,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Tbmv, Tbsv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -877,6 +906,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Tpmv, Tpsv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -918,6 +948,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Trmv, Trsv)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -963,6 +994,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Gemm)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -1013,6 +1045,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Symm)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -1063,6 +1096,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Syrk)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -1109,6 +1143,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Syr2k, Syrkx)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -1159,6 +1194,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Trmm)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -1212,6 +1248,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Trsm)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -1265,6 +1302,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Geam)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,
@@ -1315,6 +1353,7 @@ namespace ILGPU.Runtime.Cuda.API
 
 <#      foreach (var (func, nativeFunc) in GetBlasEntries(Dgmm)) { #>
 <#          if (define) { #>
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         private static extern CuBlasStatus <#= nativeFunc #>(
             IntPtr handle,

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandAPI.cs
@@ -26,17 +26,10 @@ namespace ILGPU.Runtime.Cuda.API
         /// </summary>
         /// <param name="version">The cuRand version to use.</param>
         /// <returns>The created API wrapper.</returns>
-        public static CuRandAPI Create(CuRandAPIVersion? version)
-        {
-            if (version.HasValue)
-            {
-                return CreateInternal(version.Value);
-            }
-            else
-            {
-                return CreateLatest();
-            }
-        }
+        public static CuRandAPI Create(CuRandAPIVersion? version) =>
+            version.HasValue
+            ? CreateInternal(version.Value)
+            : CreateLatest();
 
         /// <summary>
         /// Creates a new API wrapper using the latest installed version.

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandNativeMethods.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/API/CuRandNativeMethods.tt
@@ -70,59 +70,71 @@ namespace ILGPU.Runtime.Cuda.API
 
         #region Imports
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandCreateGenerator(
             out IntPtr generator,
             CuRandRngType rngType);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandCreateGeneratorHost(
             out IntPtr generator,
             CuRandRngType rngType);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandDestroyGenerator(IntPtr generator);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGetVersion(out int version);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandSetStream(
             IntPtr generator,
             IntPtr stream);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandSetPseudoRandomGeneratorSeed(
             IntPtr generator,
             long seed);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGenerateSeeds(IntPtr generator);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGenerate(
             IntPtr generator,
             IntPtr outputPtr,
             IntPtr length);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGenerateLongLong(
             IntPtr generator,
             IntPtr outputPtr,
             IntPtr length);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGenerateUniform(
             IntPtr generator,
             IntPtr outputPtr,
             IntPtr length);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGenerateUniformDouble(
             IntPtr generator,
             IntPtr outputPtr,
             IntPtr length);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGenerateNormal(
             IntPtr generator,
@@ -131,6 +143,7 @@ namespace ILGPU.Runtime.Cuda.API
             float mean,
             float stddev);
 
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
         [DllImport(LibName)]
         internal static extern CuRandStatus curandGenerateNormalDouble(
             IntPtr generator,

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlas.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlas.cs
@@ -89,6 +89,21 @@ namespace ILGPU.Runtime.Cuda
 
         #endregion
 
+        #region Static
+
+        /// <summary>
+        /// Loads a native address.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="view">The array view.</param>
+        /// <returns>The native unsafe address.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe static void* LoadCuBlasAddress<T>(ArrayView<T> view)
+            where T : unmanaged =>
+            view.LoadEffectiveAddressAsPtr().ToPointer();
+
+        #endregion
+
         #region Instance
 
         /// <summary>

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMappings.ttinclude
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMappings.ttinclude
@@ -361,7 +361,7 @@ public static IEnumerable<(string, T, string, string, string, Func<string, strin
 
         // Emit the view operand type
         yield return (entry, func, type, elemType,
-            $"ArrayView<{type}>", name => name + ".LoadEffectiveAddress()",
+            $"ArrayView<{type}>", name => $"LoadCuBlasAddress({name})",
             "EnsurePointerMode(CuBlasPointerMode.Device)");
     }
 }

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel1.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel1.tt
@@ -44,7 +44,7 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    input.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(input),
                     1,
                     &result));
             return result;
@@ -63,9 +63,9 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    input.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(input),
                     1,
-                    output.LoadEffectiveAddress()));
+                    LoadCuBlasAddress(output)));
         }
 
 <# } #>
@@ -87,7 +87,7 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    input.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(input),
                     1,
                     Unsafe.AsPointer(ref result)));
             return result;
@@ -106,9 +106,9 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     input.IntLength,
-                    input.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(input),
                     1,
-                    output.LoadEffectiveAddress()));
+                    LoadCuBlasAddress(output)));
         }
 
 <# } #>
@@ -134,9 +134,9 @@ namespace ILGPU.Runtime.Cuda
                     Handle,
                     x.IntLength,
                     <#= paramGetter("alpha") #>,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     1,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     1));
         }
 
@@ -162,9 +162,9 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     1,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     1,
                     Unsafe.AsPointer(ref result)));
             return result;
@@ -188,11 +188,11 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     1,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     1,
-                    output.LoadEffectiveAddress()));
+                    LoadCuBlasAddress(output)));
         }
 
 <# } #>
@@ -218,9 +218,9 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     1,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     1,
                     <#= paramGetter("c") #>,
                     <#= paramGetter("s") #>));
@@ -268,10 +268,10 @@ namespace ILGPU.Runtime.Cuda
             CuBlasException.ThrowIfFailed(
                 API.<#= func #>(
                     Handle,
-                    a.LoadEffectiveAddress(),
-                    b.LoadEffectiveAddress(),
-                    c.LoadEffectiveAddress(),
-                    s.LoadEffectiveAddress()));
+                    LoadCuBlasAddress(a),
+                    LoadCuBlasAddress(b),
+                    LoadCuBlasAddress(c),
+                    LoadCuBlasAddress(s)));
         }
 
 <# } #>
@@ -296,9 +296,9 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     1,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     1,
                     <#= paramGetter("param") #>));
         }
@@ -323,7 +323,7 @@ namespace ILGPU.Runtime.Cuda
                     Handle,
                     x.IntLength,
                     <#= paramGetter("alpha") #>,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     1));
         }
 
@@ -346,9 +346,9 @@ namespace ILGPU.Runtime.Cuda
                 API.<#= func #>(
                     Handle,
                     x.IntLength,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     1,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     1));
         }
 

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel2.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel2.tt
@@ -57,12 +57,12 @@ namespace ILGPU.Runtime.Cuda
                     kl,
                     ku,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
                     <#= paramGetter("beta") #>,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy));
         }
 
@@ -95,12 +95,12 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
                     <#= paramGetter("beta") #>,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy));
         }
 
@@ -130,11 +130,11 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda));
         }
 
@@ -167,12 +167,12 @@ namespace ILGPU.Runtime.Cuda
                     n,
                     k,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
                     <#= paramGetter("beta") #>,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy));
         }
 
@@ -202,11 +202,11 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    ap.LoadEffectiveAddress(),
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(ap),
+                    LoadCuBlasAddress(x),
                     incx,
                     <#= paramGetter("beta") #>,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy));
         }
 
@@ -233,9 +233,9 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
-                    ap.LoadEffectiveAddress()));
+                    LoadCuBlasAddress(ap)));
         }
 
 <# } #>
@@ -263,11 +263,11 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy,
-                    ap.LoadEffectiveAddress()));
+                    LoadCuBlasAddress(ap)));
         }
 
 <# } #>
@@ -297,12 +297,12 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
                     <#= paramGetter("beta") #>,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy));
         }
 
@@ -330,9 +330,9 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda));
         }
 
@@ -362,11 +362,11 @@ namespace ILGPU.Runtime.Cuda
                     uplo,
                     n,
                     <#= paramGetter("alpha") #>,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
-                    y.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(y),
                     incy,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda));
         }
 
@@ -397,9 +397,9 @@ namespace ILGPU.Runtime.Cuda
                     diag,
                     n,
                     k,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx));
         }
 
@@ -427,8 +427,8 @@ namespace ILGPU.Runtime.Cuda
                     trans,
                     diag,
                     n,
-                    ap.LoadEffectiveAddress(),
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(ap),
+                    LoadCuBlasAddress(x),
                     incx));
         }
 
@@ -457,9 +457,9 @@ namespace ILGPU.Runtime.Cuda
                     trans,
                     diag,
                     n,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx));
         }
 

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel3.tt
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuBlasMethodsLevel3.tt
@@ -57,12 +57,12 @@ namespace ILGPU.Runtime.Cuda
                     n,
                     k,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    b.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(b),
                     ldb,
                     <#= paramGetter("beta") #>,
-                    c.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(c),
                     ldc));
         }
 
@@ -97,12 +97,12 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    b.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(b),
                     ldb,
                     <#= paramGetter("beta") #>,
-                    c.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(c),
                     ldc));
         }
 
@@ -135,10 +135,10 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
                     <#= paramGetter("beta") #>,
-                    c.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(c),
                     ldc));
         }
 
@@ -174,12 +174,12 @@ namespace ILGPU.Runtime.Cuda
                     n,
                     k,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    b.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(b),
                     ldb,
                     <#= paramGetter("beta") #>,
-                    c.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(c),
                     ldc));
         }
 
@@ -217,11 +217,11 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    b.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(b),
                     ldb,
-                    c.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(c),
                     ldc));
         }
 
@@ -257,9 +257,9 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    b.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(b),
                     ldb));
         }
 
@@ -294,12 +294,12 @@ namespace ILGPU.Runtime.Cuda
                     m,
                     n,
                     <#= paramGetter("alpha") #>,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
                     <#= paramGetter("beta") #>,
-                    b.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(b),
                     ldb,
-                    c.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(c),
                     ldc));
         }
 
@@ -327,11 +327,11 @@ namespace ILGPU.Runtime.Cuda
                     mode,
                     m,
                     n,
-                    a.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(a),
                     lda,
-                    x.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(x),
                     incx,
-                    c.LoadEffectiveAddress(),
+                    LoadCuBlasAddress(c),
                     ldc));
         }
 

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuRand.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuRand.cs
@@ -128,15 +128,21 @@ namespace ILGPU.Runtime.Cuda
             /// </summary>
             public ArrayView<int> Data { get; }
 
-            /// <inheritdoc cref="IGridStrideKernelBody.Execute(LongIndex1)"/>
+            /// <inheritdoc cref="IGridStrideKernelBody.Execute(LongIndex1D)"/>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly void Execute(LongIndex1 linearIndex)
+            public readonly void Execute(LongIndex1D linearIndex)
             {
                 if (linearIndex >= Data.Length)
                     return;
 
                 Data[linearIndex] = ToInt((uint)Data[linearIndex]);
             }
+
+            /// <summary>
+            /// Performs no operation.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Finish() { }
         }
 
         /// <summary>
@@ -154,15 +160,21 @@ namespace ILGPU.Runtime.Cuda
             /// </summary>
             public ArrayView<long> Data { get; }
 
-            /// <inheritdoc cref="IGridStrideKernelBody.Execute(LongIndex1)"/>
+            /// <inheritdoc cref="IGridStrideKernelBody.Execute(LongIndex1D)"/>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly void Execute(LongIndex1 linearIndex)
+            public readonly void Execute(LongIndex1D linearIndex)
             {
                 if (linearIndex >= Data.Length)
                     return;
 
                 Data[linearIndex] = ToLong((ulong)Data[linearIndex]);
             }
+
+            /// <summary>
+            /// Performs no operation.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Finish() { }
         }
 
         #endregion
@@ -291,7 +303,7 @@ namespace ILGPU.Runtime.Cuda
             CuRandException.ThrowIfFailed(
                 API.GenerateUInt(
                     GeneratorPtr,
-                    new IntPtr(view.LoadEffectiveAddress()),
+                    view.LoadEffectiveAddressAsPtr(),
                     new IntPtr(view.Length)));
         }
 
@@ -309,7 +321,7 @@ namespace ILGPU.Runtime.Cuda
             CuRandException.ThrowIfFailed(
                 API.GenerateULong(
                     GeneratorPtr,
-                    new IntPtr(view.LoadEffectiveAddress()),
+                    view.LoadEffectiveAddressAsPtr(),
                     new IntPtr(view.Length)));
         }
 
@@ -352,7 +364,7 @@ namespace ILGPU.Runtime.Cuda
             CuRandException.ThrowIfFailed(
                 API.GenerateUniformFloat(
                     GeneratorPtr,
-                    new IntPtr(view.LoadEffectiveAddress()),
+                    view.LoadEffectiveAddressAsPtr(),
                     new IntPtr(view.Length)));
         }
 
@@ -365,7 +377,7 @@ namespace ILGPU.Runtime.Cuda
             CuRandException.ThrowIfFailed(
                 API.GenerateUniformDouble(
                     GeneratorPtr,
-                    new IntPtr(view.LoadEffectiveAddress()),
+                    view.LoadEffectiveAddressAsPtr(),
                     new IntPtr(view.Length)));
         }
 
@@ -386,7 +398,7 @@ namespace ILGPU.Runtime.Cuda
             CuRandException.ThrowIfFailed(
                 API.GenerateNormalFloat(
                     GeneratorPtr,
-                    new IntPtr(view.LoadEffectiveAddress()),
+                    view.LoadEffectiveAddressAsPtr(),
                     new IntPtr(view.Length),
                     mean,
                     stddev));
@@ -409,7 +421,7 @@ namespace ILGPU.Runtime.Cuda
             CuRandException.ThrowIfFailed(
                 API.GenerateNormalDouble(
                     GeneratorPtr,
-                    new IntPtr(view.LoadEffectiveAddress()),
+                    view.LoadEffectiveAddressAsPtr(),
                     new IntPtr(view.Length),
                     mean,
                     stddev));
@@ -664,6 +676,8 @@ namespace ILGPU.Runtime.Cuda
             if (disposing)
                 CuRandException.ThrowIfFailed(statusCode);
             GeneratorPtr = IntPtr.Zero;
+
+            base.Dispose(disposing);
         }
 
         #endregion

--- a/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandEnums.cs
+++ b/Src/ILGPU.Algorithms/Runtime/Cuda/CuRandEnums.cs
@@ -9,6 +9,7 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
 using System;
@@ -70,4 +71,5 @@ namespace ILGPU.Runtime.Cuda
     }
 }
 
+#pragma warning restore CA1707 // Identifiers should not contain underscores
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/Src/ILGPU.Algorithms/SequenceExtensions.cs
+++ b/Src/ILGPU.Algorithms/SequenceExtensions.cs
@@ -10,10 +10,10 @@
 // Source License. See LICENSE.txt for details
 // ---------------------------------------------------------------------------------------
 
-using ILGPU.Algorithms.Resources;
 using ILGPU.Algorithms.Sequencers;
 using ILGPU.Runtime;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace ILGPU.Algorithms
 {
@@ -24,15 +24,17 @@ namespace ILGPU.Algorithms
     /// the computed values to the given view.
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
     /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="view">The target view.</param>
     /// <param name="sequencer">The used sequencer.</param>
-    public delegate void Sequencer<T, TSequencer>(
+    public delegate void Sequencer<T, TStride, TSequencer>(
         AcceleratorStream stream,
-        ArrayView<T> view,
+        ArrayView1D<T, TStride> view,
         TSequencer sequencer)
         where T : unmanaged
+        where TStride : struct, IStride1D
         where TSequencer : struct, ISequencer<T>;
 
     /// <summary>
@@ -44,17 +46,19 @@ namespace ILGPU.Algorithms
     /// - ...
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
     /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="view">The target view.</param>
     /// <param name="sequenceBatchLength">The length of a single batch.</param>
     /// <param name="sequencer">The used sequencer.</param>
-    public delegate void BatchedSequencer<T, TSequencer>(
+    public delegate void BatchedSequencer<T, TStride, TSequencer>(
         AcceleratorStream stream,
-        ArrayView<T> view,
-        Index1 sequenceBatchLength,
+        ArrayView1D<T, TStride> view,
+        LongIndex1D sequenceBatchLength,
         TSequencer sequencer)
         where T : unmanaged
+        where TStride : struct, IStride1D
         where TSequencer : struct, ISequencer<T>;
 
     /// <summary>
@@ -66,17 +70,19 @@ namespace ILGPU.Algorithms
     /// - ...
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
     /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="view">The target view.</param>
     /// <param name="sequenceLength">The length of a single sequence.</param>
     /// <param name="sequencer">The used sequencer.</param>
-    public delegate void RepeatedSequencer<T, TSequencer>(
+    public delegate void RepeatedSequencer<T, TStride, TSequencer>(
         AcceleratorStream stream,
-        ArrayView<T> view,
-        Index1 sequenceLength,
+        ArrayView1D<T, TStride> view,
+        LongIndex1D sequenceLength,
         TSequencer sequencer)
         where T : unmanaged
+        where TStride : struct, IStride1D
         where TSequencer : struct, ISequencer<T>;
 
     /// <summary>
@@ -95,19 +101,21 @@ namespace ILGPU.Algorithms
     /// - ...
     /// </summary>
     /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
     /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
     /// <param name="stream">The accelerator stream.</param>
     /// <param name="view">The target view.</param>
     /// <param name="sequenceLength">The length of a single sequence.</param>
     /// <param name="sequenceBatchLength">The length of a single batch.</param>
     /// <param name="sequencer">The used sequencer.</param>
-    public delegate void RepeatedBatchedSequencer<T, TSequencer>(
+    public delegate void RepeatedBatchedSequencer<T, TStride, TSequencer>(
         AcceleratorStream stream,
-        ArrayView<T> view,
-        Index1 sequenceLength,
-        Index1 sequenceBatchLength,
+        ArrayView1D<T, TStride> view,
+        LongIndex1D sequenceLength,
+        LongIndex1D sequenceBatchLength,
         TSequencer sequencer)
         where T : unmanaged
+        where TStride : struct, IStride1D
         where TSequencer : struct, ISequencer<T>;
 
     #endregion
@@ -117,63 +125,105 @@ namespace ILGPU.Algorithms
     /// </summary>
     public static class SequenceExtensions
     {
-        #region Sequence
+        #region Sequence Implementation
 
         /// <summary>
-        /// The actual raw sequencer implementation.
+        /// A actual raw sequencer implementation.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
         /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
-        /// <param name="index">The current thread index.</param>
-        /// <param name="view">The target view.</param>
-        /// <param name="sequenceLength">The length of the sequence.</param>
-        /// <param name="sequenceBatchLength">
-        /// The length of a single batch within a sequence.
-        /// </param>
-        /// <param name="sequencer">The sequencer instance.</param>
-        internal static void SequenceKernel<T, TSequencer>(
-            Index1 index,
-            ArrayView<T> view,
-            Index1 sequenceLength,
-            Index1 sequenceBatchLength,
-            TSequencer sequencer)
+        internal readonly struct SequenceImplementation<
+            T,
+            TStride,
+            TSequencer> : IGridStrideKernelBody
             where T : unmanaged
+            where TStride : struct, IStride1D
             where TSequencer : struct, ISequencer<T>
         {
-            var stride = GridExtensions.GridStrideLoopStride;
-            for (var idx = index; idx < view.Length; idx += stride)
+            /// <summary>
+            /// Creates a new sequence implementation.
+            /// </summary>
+            /// <param name="sequenceLength">The length of the sequence.</param>
+            /// <param name="sequenceBatchLength">
+            /// The length of a single batch within a sequence.
+            /// </param>
+            /// <param name="sequencer">The sequencer instance.</param>
+            /// <param name="view">The parent target view.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public SequenceImplementation(
+                LongIndex1D sequenceLength,
+                LongIndex1D sequenceBatchLength,
+                ArrayView1D<T, TStride> view,
+                TSequencer sequencer)
             {
-                var sequenceIndex = (idx.X / sequenceBatchLength) % sequenceLength;
-                view[idx] = sequencer.ComputeSequenceElement(sequenceIndex);
+                SequenceLength = sequenceLength;
+                SequenceBatchLength = sequenceBatchLength;
+                View = view;
+                Sequencer = sequencer;
             }
+
+            /// <summary>
+            /// Returns length of the sequence.
+            /// </summary>
+            public LongIndex1D SequenceLength { get; }
+
+            /// <summary>
+            /// The length of a single batch within a sequence.
+            /// </summary>
+            public LongIndex1D SequenceBatchLength { get; }
+
+            /// <summary>
+            /// Returns the target view.
+            /// </summary>
+            public ArrayView1D<T, TStride> View { get; }
+
+            /// <summary>
+            /// Returns the sequencer instance.
+            /// </summary>
+            public TSequencer Sequencer { get; }
+
+            /// <summary>
+            /// Executes this sequencer wrapper.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Execute(LongIndex1D linearIndex)
+            {
+                if (linearIndex >= View.Length)
+                    return;
+
+                long sequenceIndex = (linearIndex / SequenceBatchLength)
+                    % SequenceLength;
+                View[linearIndex] = Sequencer.ComputeSequenceElement(sequenceIndex);
+            }
+
+            /// <summary>
+            /// Performs no operation.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Finish() { }
         }
+
         /// <summary>
         /// Creates a raw sequencer that is defined by the given element type and the type
         /// of the sequencer.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
         /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
-        /// <param name="minDataSize">The minimum data size for maximum occupancy.</param>
         /// <returns>The loaded sequencer.</returns>
         private static Action<
             AcceleratorStream,
-            Index1,
-            ArrayView<T>,
-            Index1,
-            Index1,
-            TSequencer> CreateRawSequencer<T, TSequencer>(
-            this Accelerator accelerator,
-            out Index1 minDataSize)
+            LongIndex1D,
+            SequenceImplementation<T, TStride, TSequencer>>
+            CreateRawSequencer<T, TStride, TSequencer>(
+            this Accelerator accelerator)
             where T : unmanaged
-            where TSequencer : struct, ISequencer<T>
-        {
-            var result = accelerator.LoadAutoGroupedKernel(
-                (Action<Index1, ArrayView<T>, Index1, Index1, TSequencer>)SequenceKernel,
-                out var info);
-            minDataSize = info.MinGroupSize.Value * info.MinGridSize.Value;
-            return result;
-        }
+            where TStride : struct, IStride1D
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.LoadGridStrideKernel<
+                SequenceImplementation<T, TStride, TSequencer>>();
 
         #endregion
 
@@ -182,33 +232,37 @@ namespace ILGPU.Algorithms
         /// the sequencer.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
         /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <returns>The loaded sequencer.</returns>
-        public static Sequencer<T, TSequencer> CreateSequencer<T, TSequencer>(
+        public static Sequencer<T, TStride, TSequencer> CreateSequencer<
+            T,
+            TStride,
+            TSequencer>(
             this Accelerator accelerator)
             where T : unmanaged
+            where TStride : struct, IStride1D
             where TSequencer : struct, ISequencer<T>
         {
-            var rawSequencer = accelerator.CreateRawSequencer<T, TSequencer>(
-                out Index1 minDataSize);
+            var rawSequencer = accelerator.CreateRawSequencer<
+                T,
+                TStride,
+                TSequencer>();
             return (stream, view, sequencer) =>
             {
                 if (!view.IsValid)
                     throw new ArgumentNullException(nameof(view));
                 if (view.Length < 1)
                     throw new ArgumentOutOfRangeException(nameof(view));
-                if (view.Length > int.MaxValue)
-                {
-                    throw new NotSupportedException(
-                        ErrorMessages.NotSupportedArrayView64);
-                }
                 rawSequencer(
                     stream,
-                    Math.Min(view.Length, minDataSize),
-                    view,
                     view.Length,
-                    1, sequencer);
+                    new SequenceImplementation<T, TStride, TSequencer>(
+                        view.Length,
+                        1L,
+                        view,
+                        sequencer));
             };
         }
 
@@ -217,18 +271,20 @@ namespace ILGPU.Algorithms
         /// type of the sequencer.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
         /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <returns>The loaded sequencer.</returns>
-        public static BatchedSequencer<T, TSequencer> CreateBatchedSequencer<
+        public static BatchedSequencer<T, TStride, TSequencer> CreateBatchedSequencer<
             T,
+            TStride,
             TSequencer>(
             this Accelerator accelerator)
             where T : unmanaged
+            where TStride : struct, IStride1D
             where TSequencer : struct, ISequencer<T>
         {
-            var rawSequencer = accelerator.CreateRawSequencer<T, TSequencer>(
-                out Index1 minDataSize);
+            var rawSequencer = accelerator.CreateRawSequencer<T, TStride, TSequencer>();
             return (stream, view, sequenceBatchLength, sequencer) =>
             {
                 if (!view.IsValid)
@@ -237,18 +293,14 @@ namespace ILGPU.Algorithms
                     throw new ArgumentOutOfRangeException(nameof(view));
                 if (sequenceBatchLength < 1)
                     throw new ArgumentOutOfRangeException(nameof(sequenceBatchLength));
-                if (view.Length > int.MaxValue)
-                {
-                    throw new NotSupportedException(
-                        ErrorMessages.NotSupportedArrayView64);
-                }
                 rawSequencer(
                     stream,
                     view.Length,
-                    view,
-                    view.Length,
-                    sequenceBatchLength,
-                    sequencer);
+                    new SequenceImplementation<T, TStride, TSequencer>(
+                        view.Length,
+                        sequenceBatchLength,
+                        view,
+                        sequencer));
             };
         }
 
@@ -257,18 +309,20 @@ namespace ILGPU.Algorithms
         /// type of the sequencer.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the target view.</typeparam>
         /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <returns>The loaded sequencer.</returns>
-        public static RepeatedSequencer<T, TSequencer> CreateRepeatedSequencer<
+        public static RepeatedSequencer<T, TStride, TSequencer> CreateRepeatedSequencer<
             T,
+            TStride,
             TSequencer>(
             this Accelerator accelerator)
             where T : unmanaged
+            where TStride : struct, IStride1D
             where TSequencer : struct, ISequencer<T>
         {
-            var rawSequencer = accelerator.CreateRawSequencer<T, TSequencer>(
-                out var minDataSize);
+            var rawSequencer = accelerator.CreateRawSequencer<T, TStride, TSequencer>();
             return (stream, view, sequenceLength, sequencer) =>
             {
                 if (!view.IsValid)
@@ -277,32 +331,34 @@ namespace ILGPU.Algorithms
                     throw new ArgumentOutOfRangeException(nameof(view));
                 if (sequenceLength < 1)
                     throw new ArgumentOutOfRangeException(nameof(sequenceLength));
-                if (view.Length > int.MaxValue)
-                {
-                    throw new NotSupportedException(
-                        ErrorMessages.NotSupportedArrayView64);
-                }
-                rawSequencer(stream, view.Length, view, sequenceLength, 1, sequencer);
+                rawSequencer(
+                    stream,
+                    view.Length,
+                    new SequenceImplementation<T, TStride, TSequencer>(
+                        sequenceLength,
+                        1L,
+                        view,
+                        sequencer));
             };
         }
-
 
         /// <summary>
         /// Creates a repeated batched sequencer that is defined by the given element type
         /// and the type of the sequencer.
         /// </summary>
         /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of all views.</typeparam>
         /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
         /// <param name="accelerator">The accelerator.</param>
         /// <returns>The loaded sequencer.</returns>
-        public static RepeatedBatchedSequencer<T, TSequencer>
-            CreateRepeatedBatchedSequencer<T, TSequencer>(
+        public static RepeatedBatchedSequencer<T, TStride, TSequencer>
+            CreateRepeatedBatchedSequencer<T, TStride, TSequencer>(
             this Accelerator accelerator)
             where T : unmanaged
+            where TStride : struct, IStride1D
             where TSequencer : struct, ISequencer<T>
         {
-            var rawSequencer = accelerator.CreateRawSequencer<T, TSequencer>(
-                out Index1 minDataSize);
+            var rawSequencer = accelerator.CreateRawSequencer<T, TStride, TSequencer>();
             return (stream, view, sequenceLength, sequenceBatchLength, sequencer) =>
             {
                 if (!view.IsValid)
@@ -313,18 +369,14 @@ namespace ILGPU.Algorithms
                     throw new ArgumentOutOfRangeException(nameof(sequenceLength));
                 if (sequenceBatchLength < 1)
                     throw new ArgumentOutOfRangeException(nameof(sequenceBatchLength));
-                if (view.Length > int.MaxValue)
-                {
-                    throw new NotSupportedException(
-                        ErrorMessages.NotSupportedArrayView64);
-                }
                 rawSequencer(
                     stream,
                     view.Length,
-                    view,
-                    sequenceLength,
-                    sequenceBatchLength,
-                    sequencer);
+                    new SequenceImplementation<T, TStride, TSequencer>(
+                        sequenceLength,
+                        sequenceBatchLength,
+                        view,
+                        sequencer));
             };
         }
 
@@ -344,13 +396,11 @@ namespace ILGPU.Algorithms
             ArrayView<T> view,
             TSequencer sequencer)
             where T : unmanaged
-            where TSequencer : struct, ISequencer<T>
-        {
-            accelerator.CreateSequencer<T, TSequencer>()(
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateSequencer<T, Stride1D.Dense, TSequencer>()(
                 stream,
                 view,
                 sequencer);
-        }
 
         /// <summary>
         /// Computes a new repeated sequence of values from 0 to sequenceLength, from 0 to
@@ -371,17 +421,15 @@ namespace ILGPU.Algorithms
             this Accelerator accelerator,
             AcceleratorStream stream,
             ArrayView<T> view,
-            Index1 sequenceLength,
+            LongIndex1D sequenceLength,
             TSequencer sequencer)
             where T : unmanaged
-            where TSequencer : struct, ISequencer<T>
-        {
-            accelerator.CreateRepeatedSequencer<T, TSequencer>()(
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateRepeatedSequencer<T, Stride1D.Dense, TSequencer>()(
                 stream,
                 view,
                 sequenceLength,
                 sequencer);
-        }
 
         /// <summary>
         /// Computes a new sequence of batched values of length sequenceBatchLength, and
@@ -402,17 +450,15 @@ namespace ILGPU.Algorithms
             this Accelerator accelerator,
             AcceleratorStream stream,
             ArrayView<T> view,
-            Index1 sequenceBatchLength,
+            LongIndex1D sequenceBatchLength,
             TSequencer sequencer)
             where T : unmanaged
-            where TSequencer : struct, ISequencer<T>
-        {
-            accelerator.CreateBatchedSequencer<T, TSequencer>()(
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateBatchedSequencer<T, Stride1D.Dense, TSequencer>()(
                 stream,
                 view,
                 sequenceBatchLength,
                 sequencer);
-        }
 
         /// <summary>
         /// Computes a new repeated sequence (of length sequenceLength) of batched values
@@ -442,18 +488,144 @@ namespace ILGPU.Algorithms
             this Accelerator accelerator,
             AcceleratorStream stream,
             ArrayView<T> view,
-            Index1 sequenceLength,
-            Index1 sequenceBatchLength,
+            LongIndex1D sequenceLength,
+            LongIndex1D sequenceBatchLength,
             TSequencer sequencer)
             where T : unmanaged
-            where TSequencer : struct, ISequencer<T>
-        {
-            accelerator.CreateRepeatedBatchedSequencer<T, TSequencer>()(
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateRepeatedBatchedSequencer<T, Stride1D.Dense, TSequencer>()(
                 stream,
                 view,
                 sequenceLength,
                 sequenceBatchLength,
                 sequencer);
-        }
+
+        /// <summary>
+        /// Computes a new sequence of values from 0 to view.Length - 1 and writes
+        /// the computed values to the given view.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
+        /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The target view.</param>
+        /// <param name="sequencer">The used sequencer.</param>
+        public static void Sequence<T, TStride, TSequencer>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> view,
+            TSequencer sequencer)
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateSequencer<T, TStride, TSequencer>()(
+                stream,
+                view,
+                sequencer);
+
+        /// <summary>
+        /// Computes a new repeated sequence of values from 0 to sequenceLength, from 0 to
+        /// sequenceLength, ... and writes the computed values to the given view.
+        /// Afterwards, the target view will contain the following values:
+        /// - [0, sequenceLength - 1] = [0, sequenceLength]
+        /// - [sequenceLength, sequenceLength * 2 -1] = [0, sequenceLength]
+        /// - ...
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
+        /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The target view.</param>
+        /// <param name="sequenceLength">The length of a single sequence.</param>
+        /// <param name="sequencer">The used sequencer.</param>
+        public static void RepeatedSequence<T, TStride, TSequencer>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> view,
+            LongIndex1D sequenceLength,
+            TSequencer sequencer)
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateRepeatedSequencer<T, TStride, TSequencer>()(
+                stream,
+                view,
+                sequenceLength,
+                sequencer);
+
+        /// <summary>
+        /// Computes a new sequence of batched values of length sequenceBatchLength, and
+        /// writes the computed values to the given view. Afterwards, the target view will
+        /// contain the following values:
+        /// - [0, sequenceBatchLength - 1] = 0,,
+        /// - [sequenceBatchLength, sequenceBatchLength * 2 -1] = 1,
+        /// - ...
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
+        /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The target view.</param>
+        /// <param name="sequenceBatchLength">The length of a single batch.</param>
+        /// <param name="sequencer">The used sequencer.</param>
+        public static void BatchedSequence<T, TStride, TSequencer>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> view,
+            LongIndex1D sequenceBatchLength,
+            TSequencer sequencer)
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateBatchedSequencer<T, TStride, TSequencer>()(
+                stream,
+                view,
+                sequenceBatchLength,
+                sequencer);
+
+        /// <summary>
+        /// Computes a new repeated sequence (of length sequenceLength) of batched values
+        /// (of length sequenceBatchLength), and writes the computed values to the given
+        /// view. Afterwards, the target view will contain the following values:
+        /// - [0, sequenceLength - 1] = 
+        ///       - [0, sequenceBatchLength - 1] = sequencer(0),
+        ///       - [sequenceBatchLength, sequenceBatchLength * 2 - 1] = sequencer(1),
+        ///       - ...
+        /// - [sequenceLength, sequenceLength * 2 - 1]
+        ///       - [sequenceLength,
+        ///          sequenceLength + sequenceBatchLength - 1] = sequencer(0),
+        ///       - [sequenceLength + sequenceBatchLength,
+        ///          sequenceLength + sequenceBatchLength * 2 - 1] = sequencer(1),
+        ///       - ...
+        /// - ...
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of the view.</typeparam>
+        /// <typeparam name="TSequencer">The type of the sequencer to use.</typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="view">The target view.</param>
+        /// <param name="sequenceLength">The length of a single sequence.</param>
+        /// <param name="sequenceBatchLength">The length of a single batch.</param>
+        /// <param name="sequencer">The used sequencer.</param>
+        public static void RepeatedBatchedSequence<T, TStride, TSequencer>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> view,
+            LongIndex1D sequenceLength,
+            LongIndex1D sequenceBatchLength,
+            TSequencer sequencer)
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TSequencer : struct, ISequencer<T> =>
+            accelerator.CreateRepeatedBatchedSequencer<T, TStride, TSequencer>()(
+                stream,
+                view,
+                sequenceLength,
+                sequenceBatchLength,
+                sequencer);
     }
 }

--- a/Src/ILGPU.Algorithms/Sequencer.cs
+++ b/Src/ILGPU.Algorithms/Sequencer.cs
@@ -27,17 +27,17 @@ namespace ILGPU.Algorithms.Sequencers
         /// The sequence index for the computation of the corresponding value.
         /// </param>
         /// <returns>The computed sequence value.</returns>
-        T ComputeSequenceElement(Index1 sequenceIndex);
+        T ComputeSequenceElement(LongIndex1D sequenceIndex);
     }
 
     /// <summary>
     /// Represents an identity implementation of an index sequencer.
     /// </summary>
-    public readonly struct IndexSequencer : ISequencer<Index1>
+    public readonly struct IndexSequencer : ISequencer<Index1D>
     {
-        /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public readonly Index1 ComputeSequenceElement(Index1 sequenceIndex) =>
-            sequenceIndex;
+        /// <summary cref="ISequencer{T}.ComputeSequenceElement(LongIndex1D)" />
+        public readonly Index1D ComputeSequenceElement(LongIndex1D sequenceIndex) =>
+            (Index1D)sequenceIndex;
     }
 
     /// <summary>
@@ -45,8 +45,8 @@ namespace ILGPU.Algorithms.Sequencers
     /// </summary>
     public readonly struct HalfSequencer : ISequencer<Half>
     {
-        /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public readonly Half ComputeSequenceElement(Index1 sequenceIndex) =>
+        /// <summary cref="ISequencer{T}.ComputeSequenceElement(LongIndex1D)" />
+        public readonly Half ComputeSequenceElement(LongIndex1D sequenceIndex) =>
             (Half)sequenceIndex.X;
     }
 
@@ -55,8 +55,8 @@ namespace ILGPU.Algorithms.Sequencers
     /// </summary>
     public readonly struct FloatSequencer : ISequencer<float>
     {
-        /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public readonly float ComputeSequenceElement(Index1 sequenceIndex) =>
+        /// <summary cref="ISequencer{T}.ComputeSequenceElement(LongIndex1D)" />
+        public readonly float ComputeSequenceElement(LongIndex1D sequenceIndex) =>
             sequenceIndex;
     }
 
@@ -65,8 +65,8 @@ namespace ILGPU.Algorithms.Sequencers
     /// </summary>
     public readonly struct DoubleSequencer : ISequencer<double>
     {
-        /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public readonly double ComputeSequenceElement(Index1 sequenceIndex) =>
+        /// <summary cref="ISequencer{T}.ComputeSequenceElement(LongIndex1D)" />
+        public readonly double ComputeSequenceElement(LongIndex1D sequenceIndex) =>
             sequenceIndex;
     }
 
@@ -94,7 +94,7 @@ namespace ILGPU.Algorithms.Sequencers
         /// <summary>
         /// Returns the i-th element of the attached <see cref="ViewSource"/>.
         /// </summary>
-        public readonly T ComputeSequenceElement(Index1 sequenceIndex) =>
+        public readonly T ComputeSequenceElement(LongIndex1D sequenceIndex) =>
             ViewSource[sequenceIndex];
     }
 }

--- a/Src/ILGPU.Algorithms/Sequencers.tt
+++ b/Src/ILGPU.Algorithms/Sequencers.tt
@@ -17,7 +17,6 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
-#pragma warning disable IDE0001 // Simplify Names
 #pragma warning disable IDE0004 // Cast is redundant
 
 using System;
@@ -35,13 +34,12 @@ namespace ILGPU.Algorithms.Sequencers
 <#      } #>
     public readonly struct <#= type.Name #>Sequencer : ISequencer<<#= type.Type #>>
     {
-        /// <summary cref="ISequencer{T}.ComputeSequenceElement(Index1)" />
-        public <#= type.Type #> ComputeSequenceElement(Index1 sequenceIndex) =>
+        /// <summary cref="ISequencer{T}.ComputeSequenceElement(LongIndex1D)" />
+        public <#= type.Type #> ComputeSequenceElement(LongIndex1D sequenceIndex) =>
             (<#= type.Type #>)sequenceIndex.X;
     }
 
 <# } #>
 }
 
-#pragma warning restore IDE0001
 #pragma warning restore IDE0004

--- a/Src/ILGPU.Algorithms/TempViewManager.cs
+++ b/Src/ILGPU.Algorithms/TempViewManager.cs
@@ -10,6 +10,7 @@
 // ---------------------------------------------------------------------------------------
 
 using ILGPU.Algorithms.Resources;
+using ILGPU.Runtime;
 using System;
 using System.Runtime.CompilerServices;
 
@@ -71,7 +72,7 @@ namespace ILGPU.Algorithms
         /// <returns>The allocated variable view.</returns>
         public VariableView<T> Allocate<T>()
             where T : unmanaged =>
-            Allocate<T>(1).GetVariableView(0);
+            Allocate<T>(1).VariableView(0);
 
         /// <summary>
         /// Allocates several elements of type <typeparamref name="T"/>.
@@ -105,9 +106,9 @@ namespace ILGPU.Algorithms
                 }
             }
 
-            var tempView = TempView.GetSubView(NumInts, viewLength);
+            var tempView = TempView.SubView(NumInts, viewLength);
             NumInts += viewLength;
-            return tempView.Cast<T>().GetSubView(0, length);
+            return tempView.Cast<T>().SubView(0, length);
         }
 
         #endregion

--- a/Src/ILGPU.Algorithms/TileInfo.cs
+++ b/Src/ILGPU.Algorithms/TileInfo.cs
@@ -28,32 +28,32 @@ namespace ILGPU.Algorithms
         /// The number of iterations per group to compute the tile size.
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public TileInfo(ArrayView<T> input, Index1 numIterationsPerGroup)
+        public TileInfo(ArrayView<T> input, Index1D numIterationsPerGroup)
         {
             TileSize = Group.DimX * numIterationsPerGroup;
             StartIndex = Grid.IdxX * TileSize + Group.IdxX;
-            EndIndex = (Grid.IdxX + Index1.One) * TileSize;
-            MaxLength = XMath.Min(input.Length, EndIndex);
+            EndIndex = (Grid.IdxX + Index1D.One) * TileSize;
+            MaxLength = XMath.Min(input.IntLength, EndIndex);
         }
 
         /// <summary>
         /// Returns the tile size.
         /// </summary>
-        public Index1 TileSize { get; }
+        public Index1D TileSize { get; }
 
         /// <summary>
         /// Returns the start index of the current thread (inclusive).
         /// </summary>
-        public Index1 StartIndex { get; }
+        public Index1D StartIndex { get; }
 
         /// <summary>
         /// Returns the end index of all threads in the group (exclusive).
         /// </summary>
-        public Index1 EndIndex { get; }
+        public Index1D EndIndex { get; }
 
         /// <summary>
         /// Returns the maximum data length to avoid out-of-bounds accesses.
         /// </summary>
-        public Index1 MaxLength { get; }
+        public Index1D MaxLength { get; }
     }
 }

--- a/Src/ILGPU.Algorithms/TransformExtensions.cs
+++ b/Src/ILGPU.Algorithms/TransformExtensions.cs
@@ -13,7 +13,7 @@
 using ILGPU.Algorithms.Resources;
 using ILGPU.Runtime;
 using System;
-using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace ILGPU.Algorithms
 {
@@ -57,28 +57,6 @@ namespace ILGPU.Algorithms
     }
 
     /// <summary>
-    /// </summary>
-    /// <typeparam name="TSource">The source value type of the transformation.</typeparam>
-    /// <typeparam name="TTarget">The target value type of the transformation.</typeparam>
-    /// <typeparam name="TTransformer">
-    /// The transformer to transform elements from the source type to the target type.
-    /// </typeparam>
-    static class TransformImpl<TSource, TTarget, TTransformer>
-        where TSource : unmanaged
-        where TTarget : unmanaged
-        where TTransformer : struct, ITransformer<TSource, TTarget>
-    {
-        /// <summary>
-        /// Represents a transform kernel.
-        /// </summary>
-        public static readonly MethodInfo KernelMethod =
-            typeof(TransformImpl<TSource, TTarget, TTransformer>).GetMethod(
-                nameof(Kernel),
-                BindingFlags.NonPublic | BindingFlags.Static);
-
-    }
-
-    /// <summary>
     /// Represents an element transformer that Transforms elements in the source view into
     /// elements in the target view using the given transformer.
     /// </summary>
@@ -103,6 +81,39 @@ namespace ILGPU.Algorithms
         where TTransformer : struct, ITransformer<TSource, TTarget>;
 
     /// <summary>
+    /// Represents an element transformer that Transforms elements in the source view into
+    /// elements in the target view using the given transformer.
+    /// </summary>
+    /// <typeparam name="TSource">The source value type of the transformation.</typeparam>
+    /// <typeparam name="TSourceStride">The 1D stride of the source view.</typeparam>
+    /// <typeparam name="TTarget">The target value type of the transformation.</typeparam>
+    /// <typeparam name="TTargetStride">The 1D stride of the target view.</typeparam>
+    /// <typeparam name="TTransformer">
+    /// The transformer to transform elements from the source type to the target type.
+    /// </typeparam>
+    /// <param name="stream">The accelerator stream.</param>
+    /// <param name="source">The source elements to transform</param>
+    /// <param name="target">
+    /// The target elements that will contain the transformed values.
+    /// </param>
+    /// <param name="transformer">The used transformer.</param>
+    public delegate void Transformer<
+        TSource,
+        TSourceStride,
+        TTarget,
+        TTargetStride,
+        TTransformer>(
+        AcceleratorStream stream,
+        ArrayView1D<TSource, TSourceStride> source,
+        ArrayView1D<TTarget, TTargetStride> target,
+        TTransformer transformer)
+        where TSource : unmanaged
+        where TSourceStride : struct, IStride1D
+        where TTarget : unmanaged
+        where TTargetStride : struct, IStride1D
+        where TTransformer : struct, ITransformer<TSource, TTarget>;
+
+    /// <summary>
     /// Transformer functionality for accelerators.
     /// </summary>
     public static class TransformExtensions
@@ -110,33 +121,74 @@ namespace ILGPU.Algorithms
         #region Transform Implementation
 
         /// <summary>
-        /// Implements a transformer algorithm.
+        /// A actual raw transform loop body.
         /// </summary>
-        /// <typeparam name="TSource">
-        /// The source value type of the transformation.
-        /// </typeparam>
-        /// <typeparam name="TTarget">
-        /// The target value type of the transformation.
-        /// </typeparam>
-        /// <typeparam name="TTransformer">
-        /// The transformer to transform elements from the source type to the target type.
-        /// </typeparam>
-        /// <param name="index"></param>
-        /// <param name="source"></param>
-        /// <param name="target"></param>
-        /// <param name="transformer"></param>
-        internal static void TransformKernel<TSource, TTarget, TTransformer>(
-            Index1 index,
-            ArrayView<TSource> source,
-            ArrayView<TTarget> target,
-            TTransformer transformer)
+        /// <typeparam name="TSource">The source element type.</typeparam>
+        /// <typeparam name="TSourceStride">The 1D stride of the source view.</typeparam>
+        /// <typeparam name="TTarget">The target element type.</typeparam>
+        /// <typeparam name="TTargetStride">The 1D stride of the target view.</typeparam>
+        /// <typeparam name="TTransformer">The type of the transformer to use.</typeparam>
+        internal readonly struct TransformImplementation<
+            TSource,
+            TSourceStride,
+            TTarget,
+            TTargetStride,
+            TTransformer> : IGridStrideKernelBody
             where TSource : unmanaged
+            where TSourceStride : struct, IStride1D
             where TTarget : unmanaged
+            where TTargetStride : struct, IStride1D
             where TTransformer : struct, ITransformer<TSource, TTarget>
         {
-            var stride = GridExtensions.GridStrideLoopStride;
-            for (var idx = index; idx < source.Length; idx += stride)
-                target[idx] = transformer.Transform(source[idx]);
+            /// <summary>
+            /// Creates a new transform instance.
+            /// </summary>
+            /// <param name="source">The parent source view.</param>
+            /// <param name="target">The parent target view.</param>
+            /// <param name="transformer">The transformer instance.</param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public TransformImplementation(
+                ArrayView1D<TSource, TSourceStride> source,
+                ArrayView1D<TTarget, TTargetStride> target,
+                TTransformer transformer)
+            {
+                Source = source;
+                Target = target;
+                Transformer = transformer;
+            }
+
+            /// <summary>
+            /// Returns the source view.
+            /// </summary>
+            public ArrayView1D<TSource, TSourceStride> Source { get; }
+
+            /// <summary>
+            /// Returns the target view.
+            /// </summary>
+            public ArrayView1D<TTarget, TTargetStride> Target { get; }
+
+            /// <summary>
+            /// Returns the transformer instance.
+            /// </summary>
+            public TTransformer Transformer { get; }
+
+            /// <summary>
+            /// Executes this transform wrapper.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Execute(LongIndex1D linearIndex)
+            {
+                if (linearIndex >= Source.Length)
+                    return;
+
+                Target[linearIndex] = Transformer.Transform(Source[linearIndex]);
+            }
+
+            /// <summary>
+            /// Performs no operation.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly void Finish() { }
         }
 
         /// <summary>
@@ -146,37 +198,43 @@ namespace ILGPU.Algorithms
         /// <typeparam name="TSource">
         /// The source value type of the transformation.
         /// </typeparam>
+        /// <typeparam name="TSourceStride">The 1D stride of the source view.</typeparam>
         /// <typeparam name="TTarget">
         /// The target value type of the transformation.
         /// </typeparam>
+        /// <typeparam name="TTargetStride">The 1D stride of the target view.</typeparam>
         /// <typeparam name="TTransformer">
         /// The transformer to transform elements from the source type to the target type.
         /// </typeparam>
         /// <param name="accelerator">The accelerator.</param>
-        /// <param name="minDataSize">The minimum data size for maximum occupancy.</param>
         /// <returns>The loaded transformer.</returns>
         private static Action<
             AcceleratorStream,
-            Index1,
-            ArrayView<TSource>,
-            ArrayView<TTarget>,
-            TTransformer> CreateRawTransformer<TSource, TTarget, TTransformer>(
-            this Accelerator accelerator,
-            out Index1 minDataSize)
-            where TSource : unmanaged
-            where TTarget : unmanaged
-            where TTransformer : struct, ITransformer<TSource, TTarget>
-        {
-            var result = accelerator.LoadAutoGroupedKernel<
-                Index1,
-                ArrayView<TSource>,
-                ArrayView<TTarget>,
+            LongIndex1D,
+            TransformImplementation<
+                TSource,
+                TSourceStride,
+                TTarget,
+                TTargetStride,
+                TTransformer>>
+            CreateRawTransformer<
+                TSource,
+                TSourceStride,
+                TTarget,
+                TTargetStride,
                 TTransformer>(
-                TransformKernel,
-                out var info);
-            minDataSize = info.MinGroupSize.Value * info.MinGridSize.Value;
-            return result;
-        }
+            this Accelerator accelerator)
+            where TSource : unmanaged
+            where TSourceStride : struct, IStride1D
+            where TTarget : unmanaged
+            where TTargetStride : struct, IStride1D
+            where TTransformer : struct, ITransformer<TSource, TTarget> =>
+            accelerator.LoadGridStrideKernel<TransformImplementation<
+                TSource,
+                TSourceStride,
+                TTarget,
+                TTargetStride,
+                TTransformer>>();
 
         #endregion
 
@@ -202,10 +260,58 @@ namespace ILGPU.Algorithms
             where TTarget : unmanaged
             where TTransformer : struct, ITransformer<TSource, TTarget>
         {
+            var transformerLauncher = accelerator.CreateTransformer<
+                TSource,
+                Stride1D.Dense,
+                TTarget,
+                Stride1D.Dense,
+                TTransformer>();
+            return (stream, source, target, transformer) =>
+                transformerLauncher(stream, source, target, transformer);
+        }
+
+        /// <summary>
+        /// Creates a raw transformer that is defined by the given source and target type
+        /// and the specified transformer type.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The source value type of the transformation.
+        /// </typeparam>
+        /// <typeparam name="TSourceStride">The 1D stride of the source view.</typeparam>
+        /// <typeparam name="TTarget">
+        /// The target value type of the transformation.
+        /// </typeparam>
+        /// <typeparam name="TTargetStride">The 1D stride of the target view.</typeparam>
+        /// <typeparam name="TTransformer">
+        /// The transformer to transform elements from the source type to the target type.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <returns>The loaded transformer.</returns>
+        public static Transformer<
+            TSource,
+            TSourceStride,
+            TTarget,
+            TTargetStride,
+            TTransformer>
+            CreateTransformer<
+                TSource,
+                TSourceStride,
+                TTarget,
+                TTargetStride,
+                TTransformer>(
+            this Accelerator accelerator)
+            where TSource : unmanaged
+            where TSourceStride : struct, IStride1D
+            where TTarget : unmanaged
+            where TTargetStride : struct, IStride1D
+            where TTransformer : struct, ITransformer<TSource, TTarget>
+        {
             var rawTransformer = accelerator.CreateRawTransformer<
                 TSource,
+                TSourceStride,
                 TTarget,
-                TTransformer>(out Index1 minDataSize);
+                TTargetStride,
+                TTransformer>();
             return (stream, source, target, transformer) =>
             {
                 if (!source.IsValid)
@@ -215,20 +321,26 @@ namespace ILGPU.Algorithms
                 if (!target.IsValid)
                     throw new ArgumentNullException(nameof(source));
                 if (target.Length < source.Length)
+                {
                     throw new ArgumentOutOfRangeException(
                         nameof(target),
-                        "The source view is larger than the target view");
-                if (source.Length > int.MaxValue)
-                {
-                    throw new NotSupportedException(
-                        ErrorMessages.NotSupportedArrayView64);
+                        string.Format(
+                            ErrorMessages.ViewOutOfRange,
+                            nameof(source),
+                            nameof(target)));
                 }
                 rawTransformer(
                     stream,
-                    Math.Min(source.Length, minDataSize),
-                    source,
-                    target,
-                    transformer);
+                    source.Length,
+                    new TransformImplementation<
+                        TSource,
+                        TSourceStride,
+                        TTarget,
+                        TTargetStride,
+                        TTransformer>(
+                        source,
+                        target,
+                        transformer));
             };
         }
 
@@ -245,10 +357,8 @@ namespace ILGPU.Algorithms
         public static Transformer<T, T, TTransformer> CreateTransformer<T, TTransformer>(
             this Accelerator accelerator)
             where T : unmanaged
-            where TTransformer : struct, ITransformer<T, T>
-        {
-            return accelerator.CreateTransformer<T, T, TTransformer>();
-        }
+            where TTransformer : struct, ITransformer<T, T> =>
+            accelerator.CreateTransformer<T, T, TTransformer>();
 
         /// <summary>
         /// Transforms elements in the source view into elements in the target view using
@@ -272,14 +382,12 @@ namespace ILGPU.Algorithms
             ArrayView<T> target,
             TTransformer transformer)
             where T : unmanaged
-            where TTransformer : struct, ITransformer<T, T>
-        {
+            where TTransformer : struct, ITransformer<T, T> =>
             accelerator.CreateTransformer<T, TTransformer>()(
                 stream,
                 source,
                 target,
                 transformer);
-        }
 
         /// <summary>
         /// Transforms elements in the source view into elements in the target view using
@@ -309,13 +417,91 @@ namespace ILGPU.Algorithms
             TTransformer transformer)
             where TSource : unmanaged
             where TTarget : unmanaged
-            where TTransformer : struct, ITransformer<TSource, TTarget>
-        {
+            where TTransformer : struct, ITransformer<TSource, TTarget> =>
             accelerator.CreateTransformer<TSource, TTarget, TTransformer>()(
                 stream,
                 source,
                 target,
                 transformer);
-        }
+
+        /// <summary>
+        /// Transforms elements in the source view into elements in the target view using
+        /// the given transformer.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements to transform.</typeparam>
+        /// <typeparam name="TStride">The 1D stride of all views.</typeparam>
+        /// <typeparam name="TTransformer">
+        /// The transformer to transform elements from the source type to the target type.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="source">The source elements to transform</param>
+        /// <param name="target">
+        /// The target elements that will contain the transformed values.
+        /// </param>
+        /// <param name="transformer">The used transformer.</param>
+        public static void Transform<T, TStride, TTransformer>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<T, TStride> source,
+            ArrayView1D<T, TStride> target,
+            TTransformer transformer)
+            where T : unmanaged
+            where TStride : struct, IStride1D
+            where TTransformer : struct, ITransformer<T, T> =>
+            accelerator.CreateTransformer<T, TStride, T, TStride, TTransformer>()(
+                stream,
+                source,
+                target,
+                transformer);
+
+        /// <summary>
+        /// Transforms elements in the source view into elements in the target view using
+        /// the given transformer.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The source type of the elements to transform.
+        /// </typeparam>
+        /// <typeparam name="TSourceStride">The 1D stride of the source view.</typeparam>
+        /// <typeparam name="TTarget">
+        /// The target type of the elements that have been transformed.
+        /// </typeparam>
+        /// <typeparam name="TTargetStride">The 1D stride of the target view.</typeparam>
+        /// <typeparam name="TTransformer">
+        /// The transformer to transform elements from the source type to the target type.
+        /// </typeparam>
+        /// <param name="accelerator">The accelerator.</param>
+        /// <param name="stream">The accelerator stream.</param>
+        /// <param name="source">The source elements to transform</param>
+        /// <param name="target">
+        /// The target elements that will contain the transformed values.
+        /// </param>
+        /// <param name="transformer">The used transformer.</param>
+        public static void Transform<
+            TSource,
+            TSourceStride,
+            TTarget,
+            TTargetStride,
+            TTransformer>(
+            this Accelerator accelerator,
+            AcceleratorStream stream,
+            ArrayView1D<TSource, TSourceStride> source,
+            ArrayView1D<TTarget, TTargetStride> target,
+            TTransformer transformer)
+            where TSource : unmanaged
+            where TSourceStride : struct, IStride1D
+            where TTarget : unmanaged
+            where TTargetStride : struct, IStride1D
+            where TTransformer : struct, ITransformer<TSource, TTarget> =>
+            accelerator.CreateTransformer<
+                TSource,
+                TSourceStride,
+                TTarget,
+                TTargetStride,
+                TTransformer>()(
+                stream,
+                source,
+                target,
+                transformer);
     }
 }

--- a/Src/ILGPU.Algorithms/VectorExtensions.cs
+++ b/Src/ILGPU.Algorithms/VectorExtensions.cs
@@ -88,8 +88,8 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AtomicAdd(this VariableView<Vector2> target, Vector2 operand)
         {
-            Atomic.Add(ref target.GetSubView<float>(Vector2XOffset).Value, operand.X);
-            Atomic.Add(ref target.GetSubView<float>(Vector2YOffset).Value, operand.Y);
+            Atomic.Add(ref target.SubView<float>(Vector2XOffset).Value, operand.X);
+            Atomic.Add(ref target.SubView<float>(Vector2YOffset).Value, operand.Y);
         }
 
         /// <summary>
@@ -100,9 +100,9 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AtomicAdd(this VariableView<Vector3> target, Vector3 operand)
         {
-            Atomic.Add(ref target.GetSubView<float>(Vector3XOffset).Value, operand.X);
-            Atomic.Add(ref target.GetSubView<float>(Vector3YOffset).Value, operand.Y);
-            Atomic.Add(ref target.GetSubView<float>(Vector3ZOffset).Value, operand.Z);
+            Atomic.Add(ref target.SubView<float>(Vector3XOffset).Value, operand.X);
+            Atomic.Add(ref target.SubView<float>(Vector3YOffset).Value, operand.Y);
+            Atomic.Add(ref target.SubView<float>(Vector3ZOffset).Value, operand.Z);
         }
 
         /// <summary>
@@ -113,10 +113,10 @@ namespace ILGPU.Algorithms
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AtomicAdd(this VariableView<Vector4> target, Vector4 operand)
         {
-            Atomic.Add(ref target.GetSubView<float>(Vector4XOffset).Value, operand.X);
-            Atomic.Add(ref target.GetSubView<float>(Vector4YOffset).Value, operand.Y);
-            Atomic.Add(ref target.GetSubView<float>(Vector4ZOffset).Value, operand.Z);
-            Atomic.Add(ref target.GetSubView<float>(Vector4WOffset).Value, operand.W);
+            Atomic.Add(ref target.SubView<float>(Vector4XOffset).Value, operand.X);
+            Atomic.Add(ref target.SubView<float>(Vector4YOffset).Value, operand.Y);
+            Atomic.Add(ref target.SubView<float>(Vector4ZOffset).Value, operand.Z);
+            Atomic.Add(ref target.SubView<float>(Vector4WOffset).Value, operand.W);
         }
 
         #endregion
@@ -128,7 +128,7 @@ namespace ILGPU.Algorithms
         /// </summary>
         /// <param name="index">The source index.</param>
         /// <returns>The converted <see cref="Vector2"/>.</returns>
-        public static Vector2 ToVector(this Index2 index)
+        public static Vector2 ToVector(this Index2D index)
         {
             return new Vector2(index.X, index.Y);
         }
@@ -138,29 +138,29 @@ namespace ILGPU.Algorithms
         /// </summary>
         /// <param name="index">The source index.</param>
         /// <returns>The converted <see cref="Vector3"/>.</returns>
-        public static Vector3 ToVector(this Index3 index)
+        public static Vector3 ToVector(this Index3D index)
         {
             return new Vector3(index.X, index.Y, index.Z);
         }
 
         /// <summary>
-        /// Converts the vector to a corresponding <see cref="Index2"/>.
+        /// Converts the vector to a corresponding <see cref="Index2D"/>.
         /// </summary>
         /// <param name="vector">The source vector.</param>
-        /// <returns>The converted <see cref="Index2"/>.</returns>
-        public static Index2 ToIndex(this Vector2 vector)
+        /// <returns>The converted <see cref="Index2D"/>.</returns>
+        public static Index2D ToIndex(this Vector2 vector)
         {
-            return new Index2((int)vector.X, (int)vector.Y);
+            return new Index2D((int)vector.X, (int)vector.Y);
         }
 
         /// <summary>
-        /// Converts the vector to a corresponding <see cref="Index3"/>.
+        /// Converts the vector to a corresponding <see cref="Index3D"/>.
         /// </summary>
         /// <param name="vector">The source vector.</param>
-        /// <returns>The converted <see cref="Index3"/>.</returns>
-        public static Index3 ToIndex(this Vector3 vector)
+        /// <returns>The converted <see cref="Index3D"/>.</returns>
+        public static Index3D ToIndex(this Vector3 vector)
         {
-            return new Index3((int)vector.X, (int)vector.Y, (int)vector.Z);
+            return new Index3D((int)vector.X, (int)vector.Y, (int)vector.Z);
         }
 
         #endregion

--- a/Src/ILGPU.Algorithms/WarpExtensions.cs
+++ b/Src/ILGPU.Algorithms/WarpExtensions.cs
@@ -32,7 +32,7 @@ namespace ILGPU.Algorithms
         /// <returns>The first lane (lane id = 0) will return reduced result.</returns>
         [IntrinsicImplementation]
         public static T Reduce<T, TReduction>(T value)
-            where T : struct
+            where T : unmanaged
             where TReduction : IScanReduceOperation<T> =>
             ILWarpExtensions.Reduce<T, TReduction>(value);
 
@@ -45,7 +45,7 @@ namespace ILGPU.Algorithms
         /// <returns>All lanes will return the reduced result.</returns>
         [IntrinsicImplementation]
         public static T AllReduce<T, TReduction>(T value)
-            where T : struct
+            where T : unmanaged
             where TReduction : IScanReduceOperation<T> =>
             ILWarpExtensions.AllReduce<T, TReduction>(value);
 
@@ -62,7 +62,7 @@ namespace ILGPU.Algorithms
         /// <returns>The resulting value for the current lane.</returns>
         [IntrinsicImplementation]
         public static T ExclusiveScan<T, TScan>(T value)
-            where T : struct
+            where T : unmanaged
             where TScan : struct, IScanReduceOperation<T> =>
             ILWarpExtensions.ExclusiveScan<T, TScan>(value);
 
@@ -75,7 +75,7 @@ namespace ILGPU.Algorithms
         /// <returns>The resulting value for the current lane.</returns>
         [IntrinsicImplementation]
         public static T InclusiveScan<T, TScan>(T value)
-            where T : struct
+            where T : unmanaged
             where TScan : struct, IScanReduceOperation<T> =>
             ILWarpExtensions.InclusiveScan<T, TScan>(value);
 


### PR DESCRIPTION
This PR adds support for the latest upstream ILGPU version in the `master` branch. Most of the extensions have been ported and partially refined to support views with length `>= int.MaxValue`.

~@MoFtZ I have partially ported the `histogram` extensions and disabled the associated test cases for now. We should discuss how to integrate support for arbitrarily strided `ArrayViewXD` views and whether this is still needed.~

~@jgiannuzzi I am not sure currently, why the T4 templates cannot be built in the CI. Did I forget to adjust anything?~